### PR TITLE
feat: support http.ResponseWriter and optimize content type

### DIFF
--- a/context_response.go
+++ b/context_response.go
@@ -63,6 +63,14 @@ func (r *ContextResponse) View() contractshttp.ResponseView {
 	return NewView(r.instance)
 }
 
+func (r *ContextResponse) Flush() {
+	r.instance.Fresh()
+}
+
+func (r *ContextResponse) Writer() http.ResponseWriter {
+	return &WriterAdapter{r.instance}
+}
+
 type WriterAdapter struct {
 	instance *fiber.Ctx
 }
@@ -82,14 +90,6 @@ func (w *WriterAdapter) Write(data []byte) (int, error) {
 
 func (w *WriterAdapter) WriteHeader(code int) {
 	w.instance.Context().SetStatusCode(code)
-}
-
-func (r *ContextResponse) Writer() http.ResponseWriter {
-	return &WriterAdapter{r.instance}
-}
-
-func (r *ContextResponse) Flush() {
-	r.instance.Fresh()
 }
 
 type Success struct {

--- a/context_response.go
+++ b/context_response.go
@@ -1,9 +1,7 @@
 package fiber
 
 import (
-	"bufio"
 	"bytes"
-	"net"
 	"net/http"
 
 	"github.com/gofiber/fiber/v2"
@@ -84,29 +82,6 @@ func (w *WriterAdapter) Write(data []byte) (int, error) {
 
 func (w *WriterAdapter) WriteHeader(code int) {
 	w.instance.Context().SetStatusCode(code)
-}
-
-func (w *WriterAdapter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
-	ch := make(chan struct {
-		conn       net.Conn
-		readWriter *bufio.ReadWriter
-	})
-
-	var err error
-
-	w.instance.Context().Hijack(func(conn net.Conn) {
-		reader := bufio.NewReader(conn)
-		writer := bufio.NewWriter(conn)
-		readWriter := bufio.NewReadWriter(reader, writer)
-
-		ch <- struct {
-			conn       net.Conn
-			readWriter *bufio.ReadWriter
-		}{conn, readWriter}
-	})
-
-	result := <-ch
-	return result.conn, result.readWriter, err
 }
 
 func (r *ContextResponse) Writer() http.ResponseWriter {

--- a/context_response_test.go
+++ b/context_response_test.go
@@ -1,6 +1,7 @@
 package fiber
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"strings"
@@ -275,6 +276,27 @@ func TestResponse(t *testing.T) {
 				return nil
 			},
 			expectCode: http.StatusMovedPermanently,
+		},
+		{
+			name:   "Writer",
+			method: "GET",
+			url:    "/writer",
+			setup: func(method, url string) error {
+				fiber.Get("/writer", func(ctx contractshttp.Context) contractshttp.Response {
+					_, err = fmt.Fprintf(ctx.Response().Writer(), "Goravel")
+					return nil
+				})
+
+				var err error
+				req, err = http.NewRequest(method, url, nil)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			},
+			expectCode: http.StatusOK,
+			expectBody: "Goravel",
 		},
 	}
 

--- a/response.go
+++ b/response.go
@@ -12,7 +12,8 @@ type DataResponse struct {
 }
 
 func (r *DataResponse) Render() error {
-	return r.instance.Status(r.code).Type(r.contentType).Send(r.data)
+	r.instance.Response().Header.SetContentType(r.contentType)
+	return r.instance.Status(r.code).Send(r.data)
 }
 
 type DownloadResponse struct {
@@ -66,7 +67,8 @@ func (r *StringResponse) Render() error {
 		return r.instance.Status(r.code).SendString(r.format)
 	}
 
-	return r.instance.Status(r.code).Type(r.format).SendString(r.values[0].(string))
+	r.instance.Response().Header.SetContentType(r.format)
+	return r.instance.Status(r.code).SendString(r.values[0].(string))
 }
 
 type HtmlResponse struct {


### PR DESCRIPTION
<!-- 
Thanks for creating this pull request 🤗

Please make sure that the pull request is limited to one type (docs, feature, etc.) and keep it as small as possible. You can open multiple prs instead of opening a huge one.
-->

<!-- If this pull request closes an issue, please mention the issue number below -->
Closes goravel/goravel#296
Closes goravel/goravel#297

## 📑 Description
<!-- Add a brief description of the pr -->
Make Fiber support http.ResponseWriter interfaces and optimize content type pass like Gin.

Notice: This Writer can't support `http.Hijack` interfaces so it can't use in gorilla's websocket package, pls use fasthttp's websocket package instead.

<!-- You can also choose to add a list of changes and if they have been completed or not by using the markdown to-do list syntax
- [ ] Not Completed
- [x] Completed
-->

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [x] My pull request adheres to the code style of this project
- [ ] My code requires changes to the documentation
- [ ] I have updated the documentation as required
- [x] All the tests have passed

## ℹ Additional Information
<!-- Any additional information like breaking changes, dependencies added, screenshots, comparisons between new and old behavior, etc. -->
