### PR TITLE
fix: [#528] GraphQL request causing errors from request body parsing

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -35,7 +35,7 @@ type ContextRequest struct {
 func NewContextRequest(ctx *Context, log log.Log, validation contractsvalidate.Validation) contractshttp.ContextRequest {
 	httpBody, err := getHttpBody(ctx)
 	if err != nil {
-		LogFacade.Error(fmt.Sprintf("%+v", errors.Unwrap(err)))
+		LogFacade.Error(fmt.Sprintf("%+v", err))
 	}
 
 	return &ContextRequest{ctx: ctx, instance: ctx.instance, httpBody: httpBody, log: log, validation: validation}
@@ -477,8 +477,10 @@ func getHttpBody(ctx *Context) (map[string]any, error) {
 	if strings.Contains(contentType, "application/json") {
 		bodyBytes := ctx.instance.Body()
 
-		if err := json.Unmarshal(bodyBytes, &data); err != nil {
-			return nil, fmt.Errorf("decode json [%v] error: %v", utils.UnsafeString(bodyBytes), err)
+		if len(bodyBytes) > 0 {
+			if err := json.Unmarshal(bodyBytes, &data); err != nil {
+				return nil, fmt.Errorf("decode json [%v] error: %v", utils.UnsafeString(bodyBytes), err)
+			}
 		}
 	}
 

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1032,6 +1032,26 @@ func (s *ContextRequestSuite) TestInputBool() {
 	s.Equal(http.StatusOK, code)
 }
 
+// Test Issue: https://github.com/goravel/goravel/issues/528
+func (s *ContextRequestSuite) TestPostWithEmpty() {
+	s.route.Post("/post-with-empty", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"all": ctx.Request().All(),
+		})
+	})
+
+	payload := strings.NewReader("")
+	req, err := http.NewRequest("POST", "/post-with-empty?a=1", payload)
+	req.ContentLength = 1
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/json")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"all\":{\"a\":\"1\"}}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestQuery() {
 	s.route.Get("/query", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/528

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for HTTP request processing to prevent misleading error messages for empty bodies.
  
- **Tests**
	- Introduced a new test for handling empty payloads in POST requests, ensuring correct JSON response for specific scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
