### PR TITLE
fix: Context method 

### DIFF
--- a/context.go
+++ b/context.go
@@ -9,16 +9,18 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-const (
-	userContextKey = "goravel_userContextKey"
-	contextKey     = "goravel_contextKey"
-	sessionKey     = "goravel_session"
-)
+type contextKeyType struct{}
+type sessionKeyType struct{}
+type userContextKeyType struct{}
 
 var (
+	contextKey          = contextKeyType{}
+	sessionKey          = sessionKeyType{}
+	userContextKey      = userContextKeyType{}
 	internalContextKeys = []any{
 		contextKey,
 		sessionKey,
+		userContextKey,
 	}
 )
 

--- a/context.go
+++ b/context.go
@@ -53,6 +53,9 @@ func (c *Context) Response() http.ContextResponse {
 func (c *Context) WithValue(key any, value any) {
 	// Not store the value in the context directly, because we want to return the value map when calling `Context()`.
 	values := c.getGoravelContextValues()
+	if values == nil {
+		values = make(map[any]any)
+	}
 	values[key] = value
 	ctx := context.WithValue(c.instance.UserContext(), contextKey, values)
 	c.instance.SetUserContext(ctx)

--- a/context_request.go
+++ b/context_request.go
@@ -139,7 +139,7 @@ func (r *ContextRequest) Host() string {
 }
 
 func (r *ContextRequest) HasSession() bool {
-	_, ok := r.ctx.Value("session").(contractsession.Session)
+	_, ok := r.ctx.Value(sessionKey).(contractsession.Session)
 	return ok
 }
 
@@ -392,7 +392,7 @@ func (r *ContextRequest) RouteInt64(key string) int64 {
 }
 
 func (r *ContextRequest) Session() contractsession.Session {
-	s, ok := r.ctx.Value("session").(contractsession.Session)
+	s, ok := r.ctx.Value(sessionKey).(contractsession.Session)
 	if !ok {
 		return nil
 	}
@@ -400,7 +400,7 @@ func (r *ContextRequest) Session() contractsession.Session {
 }
 
 func (r *ContextRequest) SetSession(session contractsession.Session) contractshttp.ContextRequest {
-	r.ctx.WithValue("session", session)
+	r.ctx.WithValue(sessionKey, session)
 
 	return r
 }

--- a/context_test.go
+++ b/context_test.go
@@ -15,6 +15,7 @@ func TestContext(t *testing.T) {
 	httpCtx.WithValue("Hello", "world")
 	httpCtx.WithValue("Hi", "Goravel")
 	httpCtx.WithValue(customTypeKey, "halo")
+	httpCtx.WithValue(sessionKey, "session")
 
 	userContext := context.Background()
 	//nolint:all
@@ -29,6 +30,7 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "halo", httpCtx.Value(customTypeKey))
 	assert.Equal(t, "one", httpCtx.Value(1))
 	assert.Equal(t, "two point two", httpCtx.Value(2.2))
+	assert.Equal(t, "session", httpCtx.Value(sessionKey))
 	assert.NotNil(t, httpCtx.Value(contextKey))
 
 	// The value of UserContext can't be covered.
@@ -41,5 +43,6 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "b", ctx.Value("user_a"))
 	assert.Equal(t, "one", ctx.Value(1))
 	assert.Equal(t, "two point two", ctx.Value(2.2))
+	assert.Nil(t, ctx.Value(sessionKey))
 	assert.Nil(t, ctx.Value(contextKey))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -1,32 +1,44 @@
 package fiber
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
 
 func TestContext(t *testing.T) {
-	type customKeyType struct{}
-	var customKey customKeyType
+	type customType struct{}
+	var customTypeKey customType
 
 	httpCtx := Background()
 	httpCtx.WithValue("Hello", "world")
 	httpCtx.WithValue("Hi", "Goravel")
-	httpCtx.WithValue(customKey, "halo")
+	httpCtx.WithValue(customTypeKey, "halo")
+
+	userContext := context.Background()
+	userContext = context.WithValue(userContext, "user_a", "b")
+	httpCtx.WithContext(userContext)
+
 	httpCtx.WithValue(1, "one")
 	httpCtx.WithValue(2.2, "two point two")
 
 	assert.Equal(t, "world", httpCtx.Value("Hello"))
 	assert.Equal(t, "Goravel", httpCtx.Value("Hi"))
-	assert.Equal(t, "halo", httpCtx.Value(customKey))
+	assert.Equal(t, "halo", httpCtx.Value(customTypeKey))
 	assert.Equal(t, "one", httpCtx.Value(1))
 	assert.Equal(t, "two point two", httpCtx.Value(2.2))
+	assert.NotNil(t, httpCtx.Value(contextKey))
+
+	// The value of UserContext can't be covered.
+	assert.Equal(t, "b", httpCtx.Value("user_a"))
 
 	ctx := httpCtx.Context()
 	assert.Equal(t, "world", ctx.Value("Hello"))
 	assert.Equal(t, "Goravel", ctx.Value("Hi"))
-	assert.Equal(t, "halo", ctx.Value(customKey))
+	assert.Equal(t, "halo", ctx.Value(customTypeKey))
+	assert.Equal(t, "b", ctx.Value("user_a"))
 	assert.Equal(t, "one", ctx.Value(1))
 	assert.Equal(t, "two point two", ctx.Value(2.2))
+	assert.Nil(t, ctx.Value(contextKey))
 }

--- a/context_test.go
+++ b/context_test.go
@@ -30,4 +30,3 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "one", ctx.Value(1))
 	assert.Equal(t, "two point two", ctx.Value(2.2))
 }
-

--- a/context_test.go
+++ b/context_test.go
@@ -17,6 +17,7 @@ func TestContext(t *testing.T) {
 	httpCtx.WithValue(customTypeKey, "halo")
 
 	userContext := context.Background()
+	//nolint:all
 	userContext = context.WithValue(userContext, "user_a", "b")
 	httpCtx.WithContext(userContext)
 


### PR DESCRIPTION
## 📑 Description

Previously, the context returned by the Context method can't get value normally, because we maintain a customized value.

<!-- Please add Review Ready tag when the PR is good to go -->
<!-- More description can be written after this -->

<!-- Do not remove this line -->
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced context management capabilities allowing for flexible storage and retrieval of multiple values.

- **Bug Fixes**
	- Improved consistency in session management by replacing hard-coded strings with a variable for session keys.

- **Tests**
	- Updated tests to validate the behavior of context value retrieval methods, including new assertions for key-value presence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- Trigger AI description by commenting @coderabbitai summary -->

