### PR TITLE
fix: [fiber驱动获取x-www-form-urlencoded数组错误]

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -571,7 +571,11 @@ func getHttpBody(ctx *Context) (map[string]any, error) {
 		args := ctx.instance.Request().PostArgs()
 		args.VisitAll(func(key, value []byte) {
 			if existValue, exist := data[utils.UnsafeString(key)]; exist {
-				data[utils.UnsafeString(key)] = append([]string{cast.ToString(existValue)}, utils.UnsafeString(value))
+				if stringSlice, ok := data[utils.UnsafeString(key)].([]string); ok {
+					data[utils.UnsafeString(key)] = append(stringSlice, utils.UnsafeString(value))
+				} else {
+					data[utils.UnsafeString(key)] = append([]string{cast.ToString(existValue)}, utils.UnsafeString(value))
+				}
 			} else {
 				data[utils.UnsafeString(key)] = utils.UnsafeString(value)
 			}

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -909,6 +909,28 @@ func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.Equal(http.StatusOK, code)
 }
 
+// Test Issue: https://github.com/goravel/goravel/issues/659
+func (s *ContextRequestSuite) TestInputArray_UrlMore() {
+	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"string":  ctx.Request().InputArray("string[]"),
+			"string1": ctx.Request().InputArray("string"),
+		})
+	})
+
+	form := neturl.Values{
+		"string[]": {"string 0", "string 1", "string 2", "string 3"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url/1?id=2", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"string\":[\"string 0\",\"string 1\",\"string 2\",\"string 3\"],\"string1\":[\"string 0\",\"string 1\",\"string 2\",\"string 3\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputMap_Default() {
 	s.route.Post("/input-map/default/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{


### PR DESCRIPTION
Closes https://github.com/goravel/goravel/issues/659

新增断言判断导致为空字符串的异常
if stringSlice, ok := data[utils.UnsafeString(key)].([]string); ok {
	data[utils.UnsafeString(key)] = append(stringSlice, utils.UnsafeString(value))
} else {
	data[utils.UnsafeString(key)] = append([]string{cast.ToString(existValue)}, utils.UnsafeString(value))
}