### PR TITLE
feat: [#510] Get origin route path

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -310,6 +310,10 @@ func (r *ContextRequest) Origin() *http.Request {
 	return &req
 }
 
+func (r *ContextRequest) OriginPath() string {
+	return colonToBracket(r.instance.Route().Path)
+}
+
 func (r *ContextRequest) Path() string {
 	return r.instance.Path()
 }

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -624,14 +624,15 @@ func (s *ContextRequestSuite) TestHeaders() {
 func (s *ContextRequestSuite) TestMethods() {
 	s.route.Get("/methods/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
-			"id":       ctx.Request().Input("id"),
-			"name":     ctx.Request().Query("name", "Hello"),
-			"header":   ctx.Request().Header("Hello", "World"),
-			"method":   ctx.Request().Method(),
-			"path":     ctx.Request().Path(),
-			"url":      ctx.Request().Url(),
-			"full_url": ctx.Request().FullUrl(),
-			"ip":       ctx.Request().Ip(),
+			"id":          ctx.Request().Input("id"),
+			"name":        ctx.Request().Query("name", "Hello"),
+			"header":      ctx.Request().Header("Hello", "World"),
+			"method":      ctx.Request().Method(),
+			"origin_path": ctx.Request().OriginPath(),
+			"path":        ctx.Request().Path(),
+			"url":         ctx.Request().Url(),
+			"full_url":    ctx.Request().FullUrl(),
+			"ip":          ctx.Request().Ip(),
 		})
 	})
 
@@ -642,7 +643,7 @@ func (s *ContextRequestSuite) TestMethods() {
 	req.Header.Set("X-Forwarded-For", "1.1.1.1")
 	code, body, _, _ := s.request(req)
 
-	s.Equal("{\"full_url\":\"\",\"header\":\"Goravel\",\"id\":\"1\",\"ip\":\"1.1.1.1\",\"method\":\"GET\",\"name\":\"Goravel\",\"path\":\"/methods/1\",\"url\":\"/methods/1?name=Goravel\"}", body)
+	s.Equal("{\"full_url\":\"\",\"header\":\"Goravel\",\"id\":\"1\",\"ip\":\"1.1.1.1\",\"method\":\"GET\",\"name\":\"Goravel\",\"origin_path\":\"/methods/{id}\",\"path\":\"/methods/1\",\"url\":\"/methods/1?name=Goravel\"}", body)
 	s.Equal(http.StatusOK, code)
 }
 

--- a/utils_test.go
+++ b/utils_test.go
@@ -9,3 +9,7 @@ import (
 func TestBracketToColon(t *testing.T) {
 	assert.Equal(t, "/:id/:name", bracketToColon("/{id}/{name}"))
 }
+
+func TestColonToBracket(t *testing.T) {
+	assert.Equal(t, "/{id}/{name}", colonToBracket("/:id/:name"))
+}


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/510

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request introduces a new method, `OriginPath`, in the `ContextRequest` struct to convert colon-based route paths to bracket-based paths. It also updates the corresponding tests to validate this functionality and adds a utility test for the conversion function `colonToBracket`.

### New functionality in `ContextRequest`:

* Added `OriginPath` method in `context_request.go` to convert colon-based route paths to bracket-based paths using the `colonToBracket` utility function. (`[context_request.goR313-R316](diffhunk://#diff-c45c9f86e31f685d97279261d96ded9782dfe0473aa5666be11e9ffa14cbe46fR313-R316)`)

### Updates to tests:

* Updated `ContextRequestSuite` tests in `context_request_test.go` to include validation for the `OriginPath` method. (`[[1]](diffhunk://#diff-44aea9709a440b6e3af7dfeccdfd7bd040b956e3c659af71e7f14c7fb207a476R631)`, `[[2]](diffhunk://#diff-44aea9709a440b6e3af7dfeccdfd7bd040b956e3c659af71e7f14c7fb207a476L645-R646)`)
* Added a unit test for the `colonToBracket` utility function in `utils_test.go`. (`[utils_test.goR12-R15](diffhunk://#diff-189b40dd496fee4378c7839f550f27e38db377a64fbe0881ce48651f0ac809faR12-R15)`)

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
