### PR TITLE
feat: [#408] Optimize the backslash

### DIFF
--- a/group.go
+++ b/group.go
@@ -37,7 +37,10 @@ func (r *Group) Group(handler route.GroupFunc) {
 	middlewares = append(middlewares, r.originMiddlewares...)
 	middlewares = append(middlewares, r.middlewares...)
 	r.middlewares = []httpcontract.Middleware{}
-	prefix := pathToFiberPath(r.originPrefix + "/" + r.prefix)
+	prefix := r.originPrefix
+	if r.prefix != "" {
+		prefix += "/" + r.prefix
+	}
 	r.prefix = ""
 
 	handler(NewGroup(r.config, r.instance, prefix, middlewares, r.lastMiddlewares))
@@ -140,7 +143,14 @@ func (r *Group) getMiddlewares(handler httpcontract.HandlerFunc) []fiber.Handler
 }
 
 func (r *Group) getPath(relativePath string) string {
-	path := pathToFiberPath(r.originPrefix + "/" + r.prefix + "/" + relativePath)
+	path := r.originPrefix
+	if r.prefix != "" {
+		path += "/" + r.prefix
+	}
+	if relativePath != "" {
+		path += "/" + relativePath
+	}
+	path = pathToFiberPath(path)
 	r.prefix = ""
 
 	return path


### PR DESCRIPTION
## 📑 Description

Closes https://github.com/goravel/goravel/issues/408

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

This pull request refactors the path-building logic in the `Group` struct and enhances test coverage for route handling. Key changes include improving path concatenation logic, renaming imports for consistency, and adding a new test case for a reported issue.

### Path-building logic improvements:
* Refactored `func (r *Group) Group(handler route.GroupFunc)` to handle path concatenation more robustly by checking for empty `prefix` values before appending slashes. (`group.go`, [group.goL40-R43](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27L40-R43))
* Updated `func (r *Group) getPath(relativePath string)` to ensure proper concatenation of `originPrefix`, `prefix`, and `relativePath` while avoiding redundant slashes. (`group.go`, [group.goL143-R153](diffhunk://#diff-996f64128c7fffe6cc8254ea4e1ac3c5693956f86ab5c8952e525083cf14ca27L143-R153))

### Test enhancements:
* Renamed `configmocks` import to `mocksconfig` for consistency and updated mock initialization in `group_test.go`. (`group_test.go`, [group_test.goL13-R24](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aL13-R24))
* Added a new test case, `TestIssue408`, to validate route handling with dynamic prefixes and ensure compatibility with issue #408. (`group_test.go`, [group_test.goL526-R562](diffhunk://#diff-176c4119baca13b177944712c9a1f0813fe8a0d03e408d7b1725f38d1bcf5a6aL526-R562))

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code
