### PR TITLE
fix: decouple context.Context interface from fiber.Ctx lifecycle and enhance timeout middleware to handle panics

### DIFF
--- a/context.go
+++ b/context.go
@@ -10,19 +10,12 @@ import (
 	"github.com/valyala/fasthttp"
 )
 
-type contextKeyType struct{}
 type sessionKeyType struct{}
-type userContextKeyType struct{}
+type sharedValuesKeyType struct{}
 
 var (
-	contextKey          = contextKeyType{}
-	sessionKey          = sessionKeyType{}
-	userContextKey      = userContextKeyType{}
-	internalContextKeys = []any{
-		contextKey,
-		sessionKey,
-		userContextKey,
-	}
+	sessionKey      = sessionKeyType{}
+	sharedValuesKey = sharedValuesKeyType{}
 )
 
 func Background() http.Context {
@@ -40,11 +33,19 @@ type Context struct {
 	instance fiber.Ctx
 	request  http.ContextRequest
 	response http.ContextResponse
+	userCtx  context.Context
+	values   map[any]any
 }
 
 func NewContext(c fiber.Ctx) *Context {
 	ctx := contextPool.Get().(*Context)
 	ctx.instance = c
+	ctx.userCtx = nil
+	if existing, ok := c.Locals(sharedValuesKey).(map[any]any); ok {
+		ctx.values = existing
+	} else {
+		ctx.values = nil
+	}
 	return ctx
 }
 
@@ -59,7 +60,7 @@ func (c *Context) Request() http.ContextRequest {
 
 func (c *Context) Response() http.ContextResponse {
 	if c.response == nil {
-		response := NewContextResponse(c.instance, &ResponseOrigin{Ctx: c.instance})
+		response := NewContextResponse(c.instance, &ResponseOrigin{Ctx: c.instance}, c)
 		c.response = response
 	}
 
@@ -67,83 +68,52 @@ func (c *Context) Response() http.ContextResponse {
 }
 
 func (c *Context) WithValue(key any, value any) {
-	// Not store the value in the context directly, because we want to return the value map when calling `Context()`.
-	values := c.getGoravelContextValues()
-	if values == nil {
-		values = make(map[any]any)
+	if c.values == nil {
+		c.values = make(map[any]any)
+		c.instance.Locals(sharedValuesKey, c.values)
 	}
-	values[key] = value
-	c.instance.Locals(contextKey, values)
+	c.values[key] = value
 }
 
 func (c *Context) WithContext(ctx context.Context) {
-	// We want to return the original context back when calling `Context()`, so we need to store it.
-	c.instance.Locals(userContextKey, ctx)
-	c.instance.SetContext(ctx)
+	c.userCtx = ctx
 }
 
 func (c *Context) Context() context.Context {
-	ctx := c.getUserContext()
-	values := c.getGoravelContextValues()
-	for key, value := range values {
-		skip := false
-		for _, internalContextKey := range internalContextKeys {
-			if key == internalContextKey {
-				skip = true
-			}
-		}
-
-		if !skip {
-			ctx = context.WithValue(ctx, key, value)
-		}
+	ctx := c.userCtx
+	if ctx == nil {
+		ctx = context.Background()
 	}
-
+	for key, value := range c.values {
+		if key == sessionKey {
+			continue
+		}
+		ctx = context.WithValue(ctx, key, value)
+	}
 	return ctx
 }
 
 func (c *Context) Deadline() (deadline time.Time, ok bool) {
-	return c.instance.Deadline()
+	return c.Context().Deadline()
 }
 
 func (c *Context) Done() <-chan struct{} {
-	return c.instance.Done()
+	return c.Context().Done()
 }
 
 func (c *Context) Err() error {
-	return c.instance.Err()
+	return c.Context().Err()
 }
 
 func (c *Context) Value(key any) any {
-	values := c.getGoravelContextValues()
-	if value, exist := values[key]; exist {
-		return value
+	if c.values != nil {
+		if v, ok := c.values[key]; ok {
+			return v
+		}
 	}
-
-	if v := c.getUserContext().Value(key); v != nil {
-		return v
-	}
-
-	return c.instance.Value(key)
+	return c.Context().Value(key)
 }
 
 func (c *Context) Instance() fiber.Ctx {
 	return c.instance
-}
-
-func (c *Context) getGoravelContextValues() map[any]any {
-	value := c.instance.Value(contextKey)
-	if goravelCtxVal, ok := value.(map[any]any); ok {
-		return goravelCtxVal
-	}
-
-	return make(map[any]any)
-}
-
-func (c *Context) getUserContext() context.Context {
-	ctx, exist := c.instance.Value(userContextKey).(context.Context)
-	if !exist {
-		ctx = context.Background()
-	}
-
-	return ctx
 }

--- a/context.go
+++ b/context.go
@@ -12,10 +12,12 @@ import (
 
 type sessionKeyType struct{}
 type sharedValuesKeyType struct{}
+type sharedUserCtxKeyType struct{}
 
 var (
-	sessionKey      = sessionKeyType{}
-	sharedValuesKey = sharedValuesKeyType{}
+	sessionKey         = sessionKeyType{}
+	sharedValuesKey    = sharedValuesKeyType{}
+	sharedUserCtxKey   = sharedUserCtxKeyType{}
 )
 
 func Background() http.Context {
@@ -40,7 +42,11 @@ type Context struct {
 func NewContext(c fiber.Ctx) *Context {
 	ctx := contextPool.Get().(*Context)
 	ctx.instance = c
-	ctx.userCtx = nil
+	if existing, ok := c.Locals(sharedUserCtxKey).(context.Context); ok {
+		ctx.userCtx = existing
+	} else {
+		ctx.userCtx = nil
+	}
 	if existing, ok := c.Locals(sharedValuesKey).(map[any]any); ok {
 		ctx.values = existing
 	} else {
@@ -77,6 +83,7 @@ func (c *Context) WithValue(key any, value any) {
 
 func (c *Context) WithContext(ctx context.Context) {
 	c.userCtx = ctx
+	c.instance.Locals(sharedUserCtxKey, ctx)
 }
 
 func (c *Context) Context() context.Context {

--- a/context_response.go
+++ b/context_response.go
@@ -21,12 +21,14 @@ var contextResponsePool = sync.Pool{New: func() any {
 type ContextResponse struct {
 	instance fiber.Ctx
 	origin   contractshttp.ResponseOrigin
+	ctx      *Context
 }
 
-func NewContextResponse(instance fiber.Ctx, origin contractshttp.ResponseOrigin) contractshttp.ContextResponse {
+func NewContextResponse(instance fiber.Ctx, origin contractshttp.ResponseOrigin, ctx *Context) contractshttp.ContextResponse {
 	response := contextResponsePool.Get().(*ContextResponse)
 	response.instance = instance
 	response.origin = origin
+	response.ctx = ctx
 	return response
 }
 
@@ -101,7 +103,7 @@ func (r *ContextResponse) Stream(code int, step func(w contractshttp.StreamWrite
 }
 
 func (r *ContextResponse) View() contractshttp.ResponseView {
-	return NewView(r.instance)
+	return NewView(r.instance, r.ctx)
 }
 
 func (r *ContextResponse) Flush() {

--- a/context_test.go
+++ b/context_test.go
@@ -31,7 +31,6 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "one", httpCtx.Value(1))
 	assert.Equal(t, "two point two", httpCtx.Value(2.2))
 	assert.Equal(t, "session", httpCtx.Value(sessionKey))
-	assert.NotNil(t, httpCtx.Value(contextKey))
 
 	// The value of UserContext can't be covered.
 	assert.Equal(t, "b", httpCtx.Value("user_a"))
@@ -44,5 +43,4 @@ func TestContext(t *testing.T) {
 	assert.Equal(t, "one", ctx.Value(1))
 	assert.Equal(t, "two point two", ctx.Value(2.2))
 	assert.Nil(t, ctx.Value(sessionKey))
-	assert.Nil(t, ctx.Value(contextKey))
 }

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -44,7 +44,7 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		case <-done:
 		case <-timeoutCtx.Done():
 			timedOut.Store(true)
-			if errors.Is(ctx.Context().Err(), context.DeadlineExceeded) {
+			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
 				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
 			}
 		}

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -3,7 +3,6 @@ package fiber
 import (
 	"context"
 	"errors"
-	"sync/atomic"
 	"time"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
@@ -25,12 +24,11 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		ctx.WithContext(timeoutCtx)
 
 		done := make(chan struct{})
-		var timedOut atomic.Bool
 
 		go func() {
 			defer func() {
 				if err := recover(); err != nil {
-					if !timedOut.Load() {
+					if timeoutCtx.Err() == nil {
 						globalRecoverCallback(ctx, err)
 					}
 				}
@@ -43,7 +41,6 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		select {
 		case <-done:
 		case <-timeoutCtx.Done():
-			timedOut.Store(true)
 			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
 				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
 			}

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -3,6 +3,7 @@ package fiber
 import (
 	"context"
 	"errors"
+	"sync/atomic"
 	"time"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
@@ -24,11 +25,14 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		ctx.WithContext(timeoutCtx)
 
 		done := make(chan struct{})
+		var timedOut atomic.Bool
 
 		go func() {
 			defer func() {
 				if err := recover(); err != nil {
-					globalRecoverCallback(ctx, err)
+					if !timedOut.Load() {
+						globalRecoverCallback(ctx, err)
+					}
 				}
 
 				close(done)
@@ -39,6 +43,7 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		select {
 		case <-done:
 		case <-timeoutCtx.Done():
+			timedOut.Store(true)
 			if errors.Is(ctx.Context().Err(), context.DeadlineExceeded) {
 				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
 			}

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -48,11 +48,6 @@ func TestTimeoutMiddleware(t *testing.T) {
 		panic("test panic")
 	})
 
-	route.Middleware(Timeout(1*time.Second)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
-		time.Sleep(2 * time.Second)
-		panic("panic after timeout")
-	})
-
 	t.Run("timeout", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/timeout", nil)
 		require.NoError(t, err)
@@ -154,15 +149,18 @@ func TestTimeoutMiddleware(t *testing.T) {
 		err := route.init(nil)
 		require.NoError(t, err)
 
-		route.Middleware(Timeout(1 * time.Second)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
-			time.Sleep(2 * time.Second)
+		panicDone := make(chan struct{})
+		route.Middleware(Timeout(100 * time.Millisecond)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+			defer close(panicDone)
+			time.Sleep(200 * time.Millisecond)
 			panic("panic after timeout")
 		})
 
 		req, err := http.NewRequest("GET", "/panic-after-timeout", nil)
 		require.NoError(t, err)
+		req.Host = "localhost"
 
-		resp, err := route.instance.Test(req, -1)
+		resp, err := route.instance.Test(req, fiber.TestConfig{Timeout: 0})
 		require.NoError(t, err)
 		require.NotNil(t, resp)
 
@@ -172,8 +170,6 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, "Request Timeout", string(body))
 
-		// Wait for the background goroutine to finish panicking and recovering
-		// without crashing the process.
-		time.Sleep(3 * time.Second)
+		<-panicDone
 	})
 }

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -48,6 +48,11 @@ func TestTimeoutMiddleware(t *testing.T) {
 		panic("test panic")
 	})
 
+	route.Middleware(Timeout(1*time.Second)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+		time.Sleep(2 * time.Second)
+		panic("panic after timeout")
+	})
+
 	t.Run("timeout", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/timeout", nil)
 		require.NoError(t, err)
@@ -131,5 +136,44 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.Equal(t, "Bad Request", string(body))
 
 		globalRecoverCallback = defaultRecoverCallback
+	})
+
+	t.Run("panic after timeout should not panic on recycled context", func(t *testing.T) {
+		mockConfig.EXPECT().Get("http.drivers.fiber.template").Return(nil).Twice()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.immutable", true).Return(true).Once()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.prefork", false).Return(false).Once()
+		mockConfig.EXPECT().Get("http.drivers.fiber.trusted_proxies").Return(nil).Once()
+		mockConfig.EXPECT().GetInt("http.drivers.fiber.body_limit", 4096).Return(4096).Once()
+		mockConfig.EXPECT().GetInt("http.drivers.fiber.header_limit", 4096).Return(4096).Once()
+		mockConfig.EXPECT().GetString("http.drivers.fiber.proxy_header", "").Return("X-Forwarded-For").Once()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.enable_trusted_proxy_check", false).Return(false).Once()
+		mockConfig.EXPECT().GetBool("app.debug", false).Return(true).Once()
+		mockConfig.EXPECT().GetString("app.timezone", "UTC").Return("UTC").Once()
+
+		globalRecoverCallback = defaultRecoverCallback
+		err := route.init(nil)
+		require.NoError(t, err)
+
+		route.Middleware(Timeout(1 * time.Second)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+			time.Sleep(2 * time.Second)
+			panic("panic after timeout")
+		})
+
+		req, err := http.NewRequest("GET", "/panic-after-timeout", nil)
+		require.NoError(t, err)
+
+		resp, err := route.instance.Test(req, -1)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+
+		// Wait for the background goroutine to finish panicking and recovering
+		// without crashing the process.
+		time.Sleep(3 * time.Second)
 	})
 }

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -35,9 +35,9 @@ func main() {
 	httpConfigPath := path.Config("http.go")
 	routeContract := "github.com/goravel/framework/contracts/route"
 	fiberFacade := "github.com/goravel/fiber/facades"
-	html := "github.com/gofiber/template/html/v2"
+	html := "github.com/gofiber/template/html/v3"
 	supportPath := "github.com/goravel/framework/support/path"
-	fiber := "github.com/gofiber/fiber/v2"
+	fiber := "github.com/gofiber/fiber/v3"
 	httpDriversConfig := match.Config("http.drivers")
 	httpConfig := match.Config("http")
 

--- a/view.go
+++ b/view.go
@@ -11,20 +11,21 @@ import (
 
 type View struct {
 	instance fiber.Ctx
+	ctx      *Context
 }
 
-func NewView(instance fiber.Ctx) *View {
-	return &View{instance: instance}
+func NewView(instance fiber.Ctx, ctx *Context) *View {
+	return &View{instance: instance, ctx: ctx}
 }
 
 func (receive *View) Make(view string, data ...any) contractshttp.Response {
 	shared := ViewFacade.GetShared()
-	if contextValues := receive.instance.Value(contextKey); contextValues != nil {
-		contextValuesMap := contextValues.(map[any]any)
-		if session := contextValuesMap[sessionKey]; session != nil {
-			sessionValue := session.(contractsession.Session)
-			token := sessionValue.Token()
-			shared["csrf_token"] = token
+	if receive.ctx != nil {
+		if session, ok := receive.ctx.values[sessionKey]; ok && session != nil {
+			if sessionValue, ok := session.(contractsession.Session); ok {
+				token := sessionValue.Token()
+				shared["csrf_token"] = token
+			}
 		}
 	}
 	if len(data) == 0 {


### PR DESCRIPTION
…ut crashing the process

## 📑 Description

Closes https://github.com/goravel/goravel/issues/

<!-- Please add Review Ready tag or leave a Review Ready message when the PR is good to go -->
<!-- More description can be written after this -->

@coderabbitai summary

## ✅ Checks

<!-- Make sure your PR passes the CI checks and do check the following fields as needed - -->
- [x] Added test cases for my code

fixes: https://github.com/goravel/goravel/issues/951