### PR TITLE
fix: use Fiber timeout middleware internally

### DIFF
--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -15,38 +15,33 @@ import (
 // without recycling the underlying request context into a later request.
 // For details, see https://github.com/valyala/fasthttp/issues/965
 func Timeout(timeout time.Duration) contractshttp.Middleware {
+	handler := fibertimeout.New(func(c fiber.Ctx) (err error) {
+		// Mirror Fiber's timeout-aware context into Goravel's request context so
+		// downstream handlers observe the same deadline and cancellation signal.
+		c.Locals(sharedUserCtxKey, c.Context())
+
+		defer func() {
+			if recovered := recover(); recovered != nil {
+				if !errors.Is(c.Context().Err(), context.DeadlineExceeded) {
+					recoverCtx := NewContext(c)
+					defer releaseContext(recoverCtx)
+					globalRecoverCallback(recoverCtx, recovered)
+				}
+				err = nil
+			}
+		}()
+
+		return c.Next()
+	}, fibertimeout.Config{Timeout: timeout})
+
 	return func(ctx contractshttp.Context) {
 		if timeout <= 0 {
 			ctx.Request().Next()
 			return
 		}
 
-		fiberCtx, ok := ctx.(*Context)
-		if !ok {
-			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
-			defer cancel()
-
-			ctx.WithContext(timeoutCtx)
-			ctx.Request().Next()
-			return
-		}
-
-		handler := fibertimeout.New(func(c fiber.Ctx) (err error) {
-			c.Locals(sharedUserCtxKey, c.Context())
-
-			defer func() {
-				if recovered := recover(); recovered != nil {
-					if !errors.Is(c.Context().Err(), context.DeadlineExceeded) {
-						recoverCtx := NewContext(c)
-						defer releaseContext(recoverCtx)
-						globalRecoverCallback(recoverCtx, recovered)
-					}
-					err = nil
-				}
-			}()
-
-			return c.Next()
-		}, fibertimeout.Config{Timeout: timeout})
+		fiberCtx := ctx.(*Context)
+		fiberCtx.Instance().SetContext(fiberCtx.Context())
 
 		if err := handler(fiberCtx.Instance()); err != nil && !errors.Is(err, fiber.ErrRequestTimeout) {
 			if err := renderFiberError(fiberCtx.Instance(), err); err != nil {

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -2,14 +2,13 @@ package fiber
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
 // Timeout creates middleware to set a timeout for a request.
-// NOTICE: It does not cancel long running executions. Underlying executions must handle timeout by using context.Context parameter.
+// NOTICE: It does not interrupt long running executions. Underlying executions must observe ctx.Done() / ctx.Err() and stop cooperatively.
 // For details, see https://github.com/valyala/fasthttp/issues/965
 func Timeout(timeout time.Duration) contractshttp.Middleware {
 	return func(ctx contractshttp.Context) {
@@ -22,28 +21,6 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		defer cancel()
 
 		ctx.WithContext(timeoutCtx)
-
-		done := make(chan struct{})
-
-		go func() {
-			defer func() {
-				if err := recover(); err != nil {
-					if timeoutCtx.Err() == nil {
-						globalRecoverCallback(ctx, err)
-					}
-				}
-
-				close(done)
-			}()
-			ctx.Request().Next()
-		}()
-
-		select {
-		case <-done:
-		case <-timeoutCtx.Done():
-			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
-				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
-			}
-		}
+		ctx.Request().Next()
 	}
 }

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -41,6 +41,9 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		}
 
 		fiberCtx := ctx.(*Context)
+		// Seed Fiber with the current Goravel context before timeout.New wraps it,
+		// otherwise upstream WithContext values would be lost when Fiber derives
+		// the timeout-aware context exposed through c.Context().
 		fiberCtx.Instance().SetContext(fiberCtx.Context())
 
 		if err := handler(fiberCtx.Instance()); err != nil && !errors.Is(err, fiber.ErrRequestTimeout) {

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -2,13 +2,17 @@ package fiber
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	contractshttp "github.com/goravel/framework/contracts/http"
+	"github.com/gofiber/fiber/v3"
+	fibertimeout "github.com/gofiber/fiber/v3/middleware/timeout"
 )
 
 // Timeout creates middleware to set a timeout for a request.
-// NOTICE: It does not interrupt long running executions. Underlying executions must observe ctx.Done() / ctx.Err() and stop cooperatively.
+// NOTICE: It relies on Fiber's timeout middleware so timed-out requests get a 408 response
+// without recycling the underlying request context into a later request.
 // For details, see https://github.com/valyala/fasthttp/issues/965
 func Timeout(timeout time.Duration) contractshttp.Middleware {
 	return func(ctx contractshttp.Context) {
@@ -17,10 +21,37 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 			return
 		}
 
-		timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
-		defer cancel()
+		fiberCtx, ok := ctx.(*Context)
+		if !ok {
+			timeoutCtx, cancel := context.WithTimeout(ctx.Context(), timeout)
+			defer cancel()
 
-		ctx.WithContext(timeoutCtx)
-		ctx.Request().Next()
+			ctx.WithContext(timeoutCtx)
+			ctx.Request().Next()
+			return
+		}
+
+		handler := fibertimeout.New(func(c fiber.Ctx) (err error) {
+			c.Locals(sharedUserCtxKey, c.Context())
+
+			defer func() {
+				if recovered := recover(); recovered != nil {
+					if !errors.Is(c.Context().Err(), context.DeadlineExceeded) {
+						recoverCtx := NewContext(c)
+						defer releaseContext(recoverCtx)
+						globalRecoverCallback(recoverCtx, recovered)
+					}
+					err = nil
+				}
+			}()
+
+			return c.Next()
+		}, fibertimeout.Config{Timeout: timeout})
+
+		if err := handler(fiberCtx.Instance()); err != nil && !errors.Is(err, fiber.ErrRequestTimeout) {
+			if err := renderFiberError(fiberCtx.Instance(), err); err != nil {
+				panic(err)
+			}
+		}
 	}
 }

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -36,6 +36,11 @@ func TestTimeoutMiddleware(t *testing.T) {
 	require.Nil(t, err)
 
 	route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	})
+
+	route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
 		select {
 		case <-time.After(2 * time.Second):
 			return nil
@@ -109,6 +114,21 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.Equal(t, "normal", string(normalBody))
 	})
 
+	t.Run("timeout context is exposed to goravel handlers", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/timeout-context", nil)
+		require.NoError(t, err)
+		req.Host = "example.com"
+		resp, err := route.instance.Test(req, fiber.TestConfig{Timeout: 0})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+	})
+
 	t.Run("panic with default recover", func(t *testing.T) {
 		mockLog := mockslog.NewLog(t)
 		mockLog.EXPECT().WithContext(mock.Anything).Return(mockLog).Once()
@@ -163,5 +183,45 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.Equal(t, "Bad Request", string(body))
 
 		globalRecoverCallback = defaultRecoverCallback
+	})
+
+	t.Run("panic after timeout should not panic on recycled context", func(t *testing.T) {
+		mockConfig.EXPECT().Get("http.drivers.fiber.template").Return(nil).Twice()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.immutable", true).Return(true).Once()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.prefork", false).Return(false).Once()
+		mockConfig.EXPECT().Get("http.drivers.fiber.trusted_proxies").Return(nil).Once()
+		mockConfig.EXPECT().GetInt("http.drivers.fiber.body_limit", 4096).Return(4096).Once()
+		mockConfig.EXPECT().GetInt("http.drivers.fiber.header_limit", 4096).Return(4096).Once()
+		mockConfig.EXPECT().GetString("http.drivers.fiber.proxy_header", "").Return("X-Forwarded-For").Once()
+		mockConfig.EXPECT().GetBool("http.drivers.fiber.enable_trusted_proxy_check", false).Return(false).Once()
+		mockConfig.EXPECT().GetBool("app.debug", false).Return(true).Once()
+		mockConfig.EXPECT().GetString("app.timezone", "UTC").Return("UTC").Once()
+
+		globalRecoverCallback = defaultRecoverCallback
+		err := route.init(nil)
+		require.NoError(t, err)
+
+		panicDone := make(chan struct{})
+		route.Middleware(Timeout(100 * time.Millisecond)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+			defer close(panicDone)
+			time.Sleep(200 * time.Millisecond)
+			panic("panic after timeout")
+		})
+
+		req, err := http.NewRequest("GET", "/panic-after-timeout", nil)
+		require.NoError(t, err)
+		req.Host = "localhost"
+
+		resp, err := route.instance.Test(req, fiber.TestConfig{Timeout: 0})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+
+		<-panicDone
 	})
 }

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -39,18 +39,17 @@ func TestTimeoutMiddleware(t *testing.T) {
 	err := route.init(nil)
 	require.Nil(t, err)
 
-	route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
+	route.Middleware(Timeout(100*time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
 		time.Sleep(200 * time.Millisecond)
 		return nil
 	})
 
-	route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
-		select {
-		case <-time.After(2 * time.Second):
-			return nil
-		case <-ctx.Done():
-			return ctx.Response().Status(contractshttp.StatusRequestTimeout).String("Request Timeout")
-		}
+	timeoutContextFired := make(chan bool, 1)
+
+	route.Middleware(Timeout(100*time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
+		timeoutContextFired <- true
+		<-ctx.Done()
+		return nil
 	})
 
 	timeoutContextValue := make(chan string, 1)
@@ -158,6 +157,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "Request Timeout", string(body))
+		assert.Equal(t, true, <-timeoutContextFired)
 	})
 
 	t.Run("panic with default recover", func(t *testing.T) {
@@ -233,7 +233,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 		require.NoError(t, err)
 
 		panicDone := make(chan struct{})
-		route.Middleware(Timeout(100 * time.Millisecond)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
+		route.Middleware(Timeout(100*time.Millisecond)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
 			defer close(panicDone)
 			time.Sleep(200 * time.Millisecond)
 			panic("panic after timeout")

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -1,6 +1,7 @@
 package fiber
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -16,6 +17,9 @@ import (
 )
 
 func TestTimeoutMiddleware(t *testing.T) {
+	type contextKey string
+	const requestIDKey contextKey = "request-id"
+
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().Get("http.drivers.fiber.template").Return(nil).Twice()
 	mockConfig.EXPECT().GetBool("http.drivers.fiber.immutable", true).Return(true).Once()
@@ -49,6 +53,17 @@ func TestTimeoutMiddleware(t *testing.T) {
 		}
 	})
 
+	timeoutContextValue := make(chan string, 1)
+
+	route.Middleware(func(ctx contractshttp.Context) {
+		ctx.WithContext(context.WithValue(ctx.Context(), requestIDKey, "goravel-timeout"))
+		ctx.Request().Next()
+	}, Timeout(100*time.Millisecond)).Get("/timeout-context-value", func(ctx contractshttp.Context) contractshttp.Response {
+		timeoutContextValue <- ctx.Value(requestIDKey).(string)
+		<-ctx.Done()
+		return nil
+	})
+
 	route.Middleware(Timeout(1*time.Second)).Get("/normal", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().String("normal")
 	})
@@ -70,6 +85,22 @@ func TestTimeoutMiddleware(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "Request Timeout", string(body))
+	})
+
+	t.Run("timeout preserves upstream context values", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/timeout-context-value", nil)
+		require.NoError(t, err)
+		req.Host = "example.com"
+		resp, err := route.instance.Test(req, fiber.TestConfig{Timeout: 0})
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+		assert.Equal(t, "goravel-timeout", <-timeoutContextValue)
 	})
 
 	t.Run("normal", func(t *testing.T) {

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -35,9 +35,13 @@ func TestTimeoutMiddleware(t *testing.T) {
 	err := route.init(nil)
 	require.Nil(t, err)
 
-	route.Middleware(Timeout(1*time.Second)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
-		time.Sleep(2 * time.Second)
-		return nil
+	route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
+		select {
+		case <-time.After(2 * time.Second):
+			return nil
+		case <-ctx.Done():
+			return ctx.Response().Status(contractshttp.StatusRequestTimeout).String("Request Timeout")
+		}
 	})
 
 	route.Middleware(Timeout(1*time.Second)).Get("/normal", func(ctx contractshttp.Context) contractshttp.Response {
@@ -75,6 +79,34 @@ func TestTimeoutMiddleware(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "normal", string(body))
+	})
+
+	t.Run("timed out request should not leak stale response into next request", func(t *testing.T) {
+		timeoutReq, err := http.NewRequest("GET", "/timeout", nil)
+		require.NoError(t, err)
+		timeoutReq.Host = "example.com"
+
+		timeoutResp, err := route.instance.Test(timeoutReq, fiber.TestConfig{Timeout: 0})
+		require.NoError(t, err)
+		require.NotNil(t, timeoutResp)
+		assert.Equal(t, contractshttp.StatusRequestTimeout, timeoutResp.StatusCode)
+
+		timeoutBody, err := io.ReadAll(timeoutResp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(timeoutBody))
+
+		normalReq, err := http.NewRequest("GET", "/normal", nil)
+		require.NoError(t, err)
+		normalReq.Host = "example.com"
+
+		normalResp, err := route.instance.Test(normalReq, fiber.TestConfig{Timeout: 0})
+		require.NoError(t, err)
+		require.NotNil(t, normalResp)
+		assert.Equal(t, http.StatusOK, normalResp.StatusCode)
+
+		normalBody, err := io.ReadAll(normalResp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "normal", string(normalBody))
 	})
 
 	t.Run("panic with default recover", func(t *testing.T) {
@@ -131,45 +163,5 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.Equal(t, "Bad Request", string(body))
 
 		globalRecoverCallback = defaultRecoverCallback
-	})
-
-	t.Run("panic after timeout should not panic on recycled context", func(t *testing.T) {
-		mockConfig.EXPECT().Get("http.drivers.fiber.template").Return(nil).Twice()
-		mockConfig.EXPECT().GetBool("http.drivers.fiber.immutable", true).Return(true).Once()
-		mockConfig.EXPECT().GetBool("http.drivers.fiber.prefork", false).Return(false).Once()
-		mockConfig.EXPECT().Get("http.drivers.fiber.trusted_proxies").Return(nil).Once()
-		mockConfig.EXPECT().GetInt("http.drivers.fiber.body_limit", 4096).Return(4096).Once()
-		mockConfig.EXPECT().GetInt("http.drivers.fiber.header_limit", 4096).Return(4096).Once()
-		mockConfig.EXPECT().GetString("http.drivers.fiber.proxy_header", "").Return("X-Forwarded-For").Once()
-		mockConfig.EXPECT().GetBool("http.drivers.fiber.enable_trusted_proxy_check", false).Return(false).Once()
-		mockConfig.EXPECT().GetBool("app.debug", false).Return(true).Once()
-		mockConfig.EXPECT().GetString("app.timezone", "UTC").Return("UTC").Once()
-
-		globalRecoverCallback = defaultRecoverCallback
-		err := route.init(nil)
-		require.NoError(t, err)
-
-		panicDone := make(chan struct{})
-		route.Middleware(Timeout(100 * time.Millisecond)).Get("/panic-after-timeout", func(ctx contractshttp.Context) contractshttp.Response {
-			defer close(panicDone)
-			time.Sleep(200 * time.Millisecond)
-			panic("panic after timeout")
-		})
-
-		req, err := http.NewRequest("GET", "/panic-after-timeout", nil)
-		require.NoError(t, err)
-		req.Host = "localhost"
-
-		resp, err := route.instance.Test(req, fiber.TestConfig{Timeout: 0})
-		require.NoError(t, err)
-		require.NotNil(t, resp)
-
-		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
-
-		body, err := io.ReadAll(resp.Body)
-		assert.NoError(t, err)
-		assert.Equal(t, "Request Timeout", string(body))
-
-		<-panicDone
 	})
 }

--- a/utils.go
+++ b/utils.go
@@ -1,6 +1,7 @@
 package fiber
 
 import (
+	"errors"
 	"regexp"
 	"strings"
 
@@ -38,13 +39,7 @@ func fiberHandlerArgs(handlers []fiber.Handler) (first any, rest []any) {
 func handlerToFiberHandler(handler httpcontract.HandlerFunc) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		context := NewContext(c)
-		defer func() {
-			contextRequestPool.Put(context.request)
-			contextResponsePool.Put(context.response)
-			context.request = nil
-			context.response = nil
-			contextPool.Put(context)
-		}()
+		defer releaseContext(context)
 
 		if response := handler(context); response != nil {
 			return response.Render()
@@ -56,17 +51,30 @@ func handlerToFiberHandler(handler httpcontract.HandlerFunc) fiber.Handler {
 func middlewareToFiberHandler(middleware httpcontract.Middleware) fiber.Handler {
 	return func(c fiber.Ctx) error {
 		context := NewContext(c)
-		defer func() {
-			contextRequestPool.Put(context.request)
-			contextResponsePool.Put(context.response)
-			context.request = nil
-			context.response = nil
-			contextPool.Put(context)
-		}()
+		defer releaseContext(context)
 
 		middleware(context)
 		return nil
 	}
+}
+
+func releaseContext(context *Context) {
+	contextRequestPool.Put(context.request)
+	contextResponsePool.Put(context.response)
+	context.request = nil
+	context.response = nil
+	contextPool.Put(context)
+}
+
+func renderFiberError(instance fiber.Ctx, err error) error {
+	var fiberErr *fiber.Error
+	if errors.As(err, &fiberErr) {
+		if sendErr := instance.Status(fiberErr.Code).SendString(fiberErr.Message); sendErr == nil {
+			return nil
+		}
+	}
+
+	return err
 }
 
 func colonToBracket(relativePath string) string {

--- a/utils.go
+++ b/utils.go
@@ -69,9 +69,11 @@ func releaseContext(context *Context) {
 func renderFiberError(instance fiber.Ctx, err error) error {
 	var fiberErr *fiber.Error
 	if errors.As(err, &fiberErr) {
-		if sendErr := instance.Status(fiberErr.Code).SendString(fiberErr.Message); sendErr == nil {
-			return nil
+		if sendErr := instance.Status(fiberErr.Code).SendString(fiberErr.Message); sendErr != nil {
+			return sendErr
 		}
+
+		return nil
 	}
 
 	return err


### PR DESCRIPTION
## Summary
- Keep `fiber.Timeout(...)` returning automatic `408 Request Timeout` responses while delegating the actual timeout handling to Fiber's built-in timeout middleware
- Propagate Fiber's timeout context into Goravel handlers so `ctx.Done()` and `ctx.Err()` still reflect the active request timeout
- Add regression coverage for stale-response leakage and for panics that happen after a request has already timed out

Closes https://github.com/goravel/goravel/issues/966

## Why
The previous Goravel timeout implementation raced a background goroutine against the request deadline and could return a timeout response while the original handler kept running on request-scoped state that was already eligible for reuse. That is the same lifecycle bug class behind the original response contamination issue.

This change keeps the public timeout feature but moves the implementation onto Fiber's native timeout middleware, which abandons timed-out request contexts instead of recycling them into later requests. Goravel handlers still receive the timeout context through `ctx.Done()` so cooperative cancellation continues to work, while the underlying Fiber request lifecycle remains safe.

```go
route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
	time.Sleep(200 * time.Millisecond)
	return nil
})

route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
	select {
	case <-time.After(2 * time.Second):
		return nil // before: Goravel raced this work in the background after returning 408
	case <-ctx.Done():
		return ctx.Response().Status(contractshttp.StatusRequestTimeout).String("Request Timeout") // after: Fiber owns the timeout and Goravel still sees cancellation
	}
})
```