### PR TITLE
fix: backport timeout context sync to v1.17.x

### DIFF
--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -5,11 +5,13 @@ import (
 	"errors"
 	"time"
 
+	"github.com/gofiber/fiber/v2"
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
 // Timeout creates middleware to set a timeout for a request.
-// NOTICE: It does not cancel long running executions. Underlying executions must handle timeout by using context.Context parameter.
+// NOTICE: It relies on Fiber's timeout-aware context and fasthttp's timeout response
+// path so timed-out requests don't leak their stale response into later requests.
 // For details, see https://github.com/valyala/fasthttp/issues/965
 func Timeout(timeout time.Duration) contractshttp.Middleware {
 	return func(ctx contractshttp.Context) {
@@ -23,24 +25,35 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 
 		ctx.WithContext(timeoutCtx)
 
+		fiberCtx := ctx.(*Context).Instance()
+		detachedCtx := cloneFiberContext(ctx.(*Context))
+		detachedInstance := detachedCtx.Instance()
 		done := make(chan struct{})
 
 		go func() {
 			defer func() {
-				if err := recover(); err != nil {
-					globalRecoverCallback(ctx, err)
+				if recovered := recover(); recovered != nil {
+					if timeoutCtx.Err() == nil {
+						globalRecoverCallback(detachedCtx, recovered)
+					}
 				}
 
+				detachedInstance.App().ReleaseCtx(detachedInstance)
+				releaseContext(detachedCtx)
 				close(done)
 			}()
-			ctx.Request().Next()
+
+			detachedCtx.Request().Next()
 		}()
 
 		select {
 		case <-done:
 		case <-timeoutCtx.Done():
-			if errors.Is(ctx.Context().Err(), context.DeadlineExceeded) {
-				ctx.Request().Abort(contractshttp.StatusRequestTimeout)
+			if errors.Is(timeoutCtx.Err(), context.DeadlineExceeded) {
+				if err := fiberCtx.Status(fiber.ErrRequestTimeout.Code).SendString(fiber.ErrRequestTimeout.Message); err != nil {
+					panic(err)
+				}
+				fiberCtx.Context().TimeoutErrorWithResponse(fiberCtx.Response())
 			}
 		}
 	}

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -1,6 +1,7 @@
 package fiber
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"testing"
@@ -15,6 +16,9 @@ import (
 )
 
 func TestTimeoutMiddleware(t *testing.T) {
+	type contextKey string
+	const requestIDKey contextKey = "request-id"
+
 	mockConfig := mocksconfig.NewConfig(t)
 	mockConfig.EXPECT().Get("http.drivers.fiber.template").Return(nil).Twice()
 	mockConfig.EXPECT().GetBool("http.drivers.fiber.immutable", true).Return(true).Once()
@@ -34,8 +38,27 @@ func TestTimeoutMiddleware(t *testing.T) {
 	err := route.init(nil)
 	require.Nil(t, err)
 
-	route.Middleware(Timeout(1*time.Second)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
-		time.Sleep(2 * time.Second)
+	route.Middleware(Timeout(100*time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
+		time.Sleep(200 * time.Millisecond)
+		return nil
+	})
+
+	timeoutContextFired := make(chan bool, 1)
+
+	route.Middleware(Timeout(100*time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
+		timeoutContextFired <- true
+		<-ctx.Done()
+		return nil
+	})
+
+	timeoutContextValue := make(chan string, 1)
+
+	route.Middleware(func(ctx contractshttp.Context) {
+		ctx.WithContext(context.WithValue(ctx.Context(), requestIDKey, "goravel-timeout"))
+		ctx.Request().Next()
+	}, Timeout(100*time.Millisecond)).Get("/timeout-context-value", func(ctx contractshttp.Context) contractshttp.Response {
+		timeoutContextValue <- ctx.Value(requestIDKey).(string)
+		<-ctx.Done()
 		return nil
 	})
 
@@ -62,6 +85,22 @@ func TestTimeoutMiddleware(t *testing.T) {
 		assert.Equal(t, "Request Timeout", string(body))
 	})
 
+	t.Run("timeout preserves upstream context values", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/timeout-context-value", nil)
+		require.NoError(t, err)
+
+		resp, err := route.instance.Test(req, -1)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+		assert.Equal(t, "goravel-timeout", <-timeoutContextValue)
+	})
+
 	t.Run("normal", func(t *testing.T) {
 		req, err := http.NewRequest("GET", "/normal", nil)
 		require.NoError(t, err)
@@ -74,6 +113,48 @@ func TestTimeoutMiddleware(t *testing.T) {
 		body, err := io.ReadAll(resp.Body)
 		assert.NoError(t, err)
 		assert.Equal(t, "normal", string(body))
+	})
+
+	t.Run("timed out request should not leak stale response into next request", func(t *testing.T) {
+		timeoutReq, err := http.NewRequest("GET", "/timeout", nil)
+		require.NoError(t, err)
+
+		timeoutResp, err := route.instance.Test(timeoutReq, -1)
+		require.NoError(t, err)
+		require.NotNil(t, timeoutResp)
+		assert.Equal(t, contractshttp.StatusRequestTimeout, timeoutResp.StatusCode)
+
+		timeoutBody, err := io.ReadAll(timeoutResp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(timeoutBody))
+
+		normalReq, err := http.NewRequest("GET", "/normal", nil)
+		require.NoError(t, err)
+
+		normalResp, err := route.instance.Test(normalReq, -1)
+		require.NoError(t, err)
+		require.NotNil(t, normalResp)
+		assert.Equal(t, http.StatusOK, normalResp.StatusCode)
+
+		normalBody, err := io.ReadAll(normalResp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "normal", string(normalBody))
+	})
+
+	t.Run("timeout context is exposed to goravel handlers", func(t *testing.T) {
+		req, err := http.NewRequest("GET", "/timeout-context", nil)
+		require.NoError(t, err)
+
+		resp, err := route.instance.Test(req, -1)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		assert.Equal(t, contractshttp.StatusRequestTimeout, resp.StatusCode)
+
+		body, err := io.ReadAll(resp.Body)
+		assert.NoError(t, err)
+		assert.Equal(t, "Request Timeout", string(body))
+		assert.Equal(t, true, <-timeoutContextFired)
 	})
 
 	t.Run("panic with default recover", func(t *testing.T) {

--- a/utils.go
+++ b/utils.go
@@ -1,8 +1,10 @@
 package fiber
 
 import (
+	"reflect"
 	"regexp"
 	"strings"
+	"unsafe"
 
 	"github.com/gofiber/fiber/v2"
 	httpcontract "github.com/goravel/framework/contracts/http"
@@ -24,13 +26,7 @@ func middlewaresToFiberHandlers(middlewares []httpcontract.Middleware) []fiber.H
 func handlerToFiberHandler(handler httpcontract.HandlerFunc) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		context := NewContext(c)
-		defer func() {
-			contextRequestPool.Put(context.request)
-			contextResponsePool.Put(context.response)
-			context.request = nil
-			context.response = nil
-			contextPool.Put(context)
-		}()
+		defer releaseContext(context)
 
 		if response := handler(context); response != nil {
 			return response.Render()
@@ -42,17 +38,48 @@ func handlerToFiberHandler(handler httpcontract.HandlerFunc) fiber.Handler {
 func middlewareToFiberHandler(middleware httpcontract.Middleware) fiber.Handler {
 	return func(c *fiber.Ctx) error {
 		context := NewContext(c)
-		defer func() {
-			contextRequestPool.Put(context.request)
-			contextResponsePool.Put(context.response)
-			context.request = nil
-			context.response = nil
-			contextPool.Put(context)
-		}()
+		defer releaseContext(context)
 
 		middleware(context)
 		return nil
 	}
+}
+
+func cloneFiberContext(context *Context) *Context {
+	instance := context.Instance()
+	clone := instance.App().AcquireCtx(instance.Context())
+
+	source := reflect.ValueOf(instance).Elem()
+	target := reflect.ValueOf(clone).Elem()
+	typeOfCtx := source.Type()
+
+	for i := 0; i < source.NumField(); i++ {
+		field := typeOfCtx.Field(i)
+		if field.Name == "viewBindMap" {
+			continue
+		}
+
+		targetField := target.Field(i)
+		sourceField := source.Field(i)
+		reflect.NewAt(targetField.Type(), unsafe.Pointer(targetField.UnsafeAddr())).Elem().Set(
+			reflect.NewAt(sourceField.Type(), unsafe.Pointer(sourceField.UnsafeAddr())).Elem(),
+		)
+	}
+
+	return NewContext(clone)
+}
+
+func releaseContext(context *Context) {
+	if context.request != nil {
+		contextRequestPool.Put(context.request)
+	}
+	if context.response != nil {
+		contextResponsePool.Put(context.response)
+	}
+	context.request = nil
+	context.response = nil
+	context.instance = nil
+	contextPool.Put(context)
 }
 
 func colonToBracket(relativePath string) string {


### PR DESCRIPTION
## Summary
- Return a stable `408 Request Timeout` response on `v1.17.x` without letting a timed-out Fiber request leak its stale response into the next request.
- Keep the timeout cancellation signal and upstream context values visible to Goravel handlers while the request is timing out.
- Add regression coverage for timeout context propagation, timeout responses, and follow-up requests after a timeout.

## Why
The original `v1.17.x` timeout middleware raced a timed-out request against Fiber's pooled request context. That allowed a slow handler to keep mutating a request after the timeout response had already been sent, which could surface stale state in a later request. This backport keeps the live request on a detached Fiber context, then asks `fasthttp` to preserve the timeout response instead of recycling the timed-out request.

```go
route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout-context", func(ctx contractshttp.Context) contractshttp.Response {
    <-ctx.Done()
    return nil
})
```

Before this fix, a timed-out request could keep running on the pooled Fiber context after `408 Request Timeout` had been returned. After this fix, the timeout response is frozen immediately while handlers still observe the deadline through `ctx.Done()` and upstream values via `ctx.Value(...)`.

```go
route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
    time.Sleep(200 * time.Millisecond) // timed-out handler keeps running on the original pooled request
    return nil
})

route.Middleware(Timeout(100 * time.Millisecond)).Get("/timeout", func(ctx contractshttp.Context) contractshttp.Response {
    time.Sleep(200 * time.Millisecond) // timed-out handler runs on a detached Fiber context
    return nil
})
```