### PR TITLE
fix: preserve single input array values

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -395,6 +395,14 @@ func (r *ContextRequest) Input(key string, defaultValue ...string) string {
 
 func (r *ContextRequest) InputArray(key string, defaultValue ...[]string) []string {
 	if valueFromHttpBody := r.getValueFromHttpBody(key); valueFromHttpBody != nil {
+		if value, ok := valueFromHttpBody.(string); ok {
+			if value == "" {
+				return []string{}
+			}
+
+			return []string{value}
+		}
+
 		if value := cast.ToStringSlice(valueFromHttpBody); value == nil {
 			return []string{}
 		} else {

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1092,6 +1092,31 @@ func (s *ContextRequestSuite) TestInputArray_Form() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormSingleValueWithSpaces() {
+	s.route.Post("/input-array/form-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("prompt_content_text[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-single/1", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -1110,6 +1135,26 @@ func (s *ContextRequestSuite) TestInputArray_Url() {
 	code, body, _, _ := s.request(req)
 
 	s.Equal("{\"string\":[\"string 0\",\"string 1\"],\"string1\":[\"string 0\",\"string 1\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlSingleValueWithSpaces() {
+	s.route.Post("/input-array/url-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	form := neturl.Values{
+		"prompt_content_text[]": {"123 456 789"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-single/1", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\"]}", body)
 	s.Equal(http.StatusOK, code)
 }
 

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1117,6 +1117,34 @@ func (s *ContextRequestSuite) TestInputArray_FormSingleValueWithSpaces() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormMultipleValuesWithSpaces() {
+	s.route.Post("/input-array/form-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("prompt_content_text[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.WriteField("prompt_content_text[]", "abc def ghi")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-multiple/1", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\",\"abc def ghi\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -1155,6 +1183,26 @@ func (s *ContextRequestSuite) TestInputArray_UrlSingleValueWithSpaces() {
 	code, body, _, _ := s.request(req)
 
 	s.Equal("{\"prompt_content_text\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlMultipleValuesWithSpaces() {
+	s.route.Post("/input-array/url-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	form := neturl.Values{
+		"prompt_content_text[]": {"123 456 789", "abc def ghi"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-multiple/1", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\",\"abc def ghi\"]}", body)
 	s.Equal(http.StatusOK, code)
 }
 


### PR DESCRIPTION
## Summary
- Preserve single form and urlencoded array values containing spaces as one array element.
- Keep existing array handling for multi-value inputs and empty values.
- Add regression coverage for multipart and urlencoded single-value arrays.

Closes https://github.com/goravel/goravel/issues/961

## Why
Goravel apps use `InputArray` to read repeated form inputs. A single submitted value containing spaces must remain one array element; otherwise user-entered text is corrupted before controller logic sees it.

Before this fix, a request with one `prompt_content_text[]` value of `123 456 789` was returned as three elements. After this fix, the same application code receives one element while repeated values still return multiple elements.

```go
func (r *PromptController) Store(ctx http.Context) http.Response {
	contentText := ctx.Request().InputArray("prompt_content_text[]")

	return ctx.Response().Success().Json(http.Json{
		"prompt_content_text": contentText,
	})
}
```