### PR TITLE
fix: preserve single input array values

### DIFF
--- a/context_request.go
+++ b/context_request.go
@@ -392,6 +392,14 @@ func (r *ContextRequest) Input(key string, defaultValue ...string) string {
 
 func (r *ContextRequest) InputArray(key string, defaultValue ...[]string) []string {
 	if valueFromHttpBody := r.getValueFromHttpBody(key); valueFromHttpBody != nil {
+		if value, ok := valueFromHttpBody.(string); ok {
+			if value == "" {
+				return []string{}
+			}
+
+			return []string{value}
+		}
+
 		if value := cast.ToStringSlice(valueFromHttpBody); value == nil {
 			return []string{}
 		} else {

--- a/context_request_test.go
+++ b/context_request_test.go
@@ -1092,6 +1092,59 @@ func (s *ContextRequestSuite) TestInputArray_Form() {
 	s.Equal(http.StatusOK, code)
 }
 
+func (s *ContextRequestSuite) TestInputArray_FormSingleValueWithSpaces() {
+	s.route.Post("/input-array/form-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("prompt_content_text[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-single/1", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_FormMultipleValuesWithSpaces() {
+	s.route.Post("/input-array/form-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	payload := &bytes.Buffer{}
+	writer := multipart.NewWriter(payload)
+	err := writer.WriteField("prompt_content_text[]", "123 456 789")
+	s.Require().Nil(err)
+
+	err = writer.WriteField("prompt_content_text[]", "abc def ghi")
+	s.Require().Nil(err)
+
+	err = writer.Close()
+	s.Require().Nil(err)
+
+	req, err := http.NewRequest("POST", "/input-array/form-multiple/1", payload)
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\",\"abc def ghi\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
 func (s *ContextRequestSuite) TestInputArray_Url() {
 	s.route.Post("/input-array/url/{id}", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Success().Json(contractshttp.Json{
@@ -1110,6 +1163,46 @@ func (s *ContextRequestSuite) TestInputArray_Url() {
 	code, body, _, _ := s.request(req)
 
 	s.Equal("{\"string\":[\"string 0\",\"string 1\"],\"string1\":[\"string 0\",\"string 1\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlSingleValueWithSpaces() {
+	s.route.Post("/input-array/url-single/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	form := neturl.Values{
+		"prompt_content_text[]": {"123 456 789"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-single/1", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\"]}", body)
+	s.Equal(http.StatusOK, code)
+}
+
+func (s *ContextRequestSuite) TestInputArray_UrlMultipleValuesWithSpaces() {
+	s.route.Post("/input-array/url-multiple/{id}", func(ctx contractshttp.Context) contractshttp.Response {
+		return ctx.Response().Success().Json(contractshttp.Json{
+			"prompt_content_text": ctx.Request().InputArray("prompt_content_text[]"),
+		})
+	})
+
+	form := neturl.Values{
+		"prompt_content_text[]": {"123 456 789", "abc def ghi"},
+	}
+	req, err := http.NewRequest("POST", "/input-array/url-multiple/1", strings.NewReader(form.Encode()))
+	s.Require().Nil(err)
+
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	code, body, _, _ := s.request(req)
+
+	s.Equal("{\"prompt_content_text\":[\"123 456 789\",\"abc def ghi\"]}", body)
 	s.Equal(http.StatusOK, code)
 }
 

--- a/group.go
+++ b/group.go
@@ -182,7 +182,7 @@ func (r *Group) getHandlerName(handler any) string {
 			prefix string
 			t      = reflect.TypeOf(res)
 		)
-		if t.Kind() == reflect.Ptr {
+		if t.Kind() == reflect.Pointer {
 			prefix = "*"
 			t = t.Elem()
 		}


### PR DESCRIPTION
## Summary
- Preserve single multipart form array values containing spaces as one array element.
- Preserve single URL-encoded array values containing spaces as one array element.
- Keep route handler name detection compatible with current Go vet reflect constant expectations.

## Why
`InputArray` should reflect the submitted array value instead of splitting a single value by whitespace. Form and URL-encoded requests store a single submitted array field as a string, so a value like `123 456 789` was previously split into multiple elements.

```go
facades.Route().Post("prompts", func(ctx http.Context) http.Response {
	values := ctx.Request().InputArray("prompt_content_text[]")

	return ctx.Response().Success().Json(http.Json{
		"prompt_content_text": values,
	})
})
```

With this change, the same user-facing code returns `[]string{"123 456 789"}` for a single submitted value and still returns multiple elements when the request submits multiple values. The route handler name logic keeps the same runtime behavior while using the current `reflect.Kind` constant expected by vet.
