### PR TITLE
fix: recursive template scanning for subdirectory views

### DIFF
--- a/template.go
+++ b/template.go
@@ -3,6 +3,7 @@ package fiber
 import (
 	"html/template"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -140,18 +141,16 @@ func (m *Template) Render(w io.Writer, name string, data any, layouts ...string)
 }
 
 func walkTmplFiles(dir string, leftDelim string, fn func(filePath string, name string)) error {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
+	return filepath.WalkDir(dir, func(filePath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
 		}
-		if filepath.Ext(entry.Name()) != ".tmpl" {
-			continue
+		if d.IsDir() {
+			return nil
 		}
-		filePath := filepath.Join(dir, entry.Name())
+		if filepath.Ext(d.Name()) != ".tmpl" {
+			return nil
+		}
 		content, err := os.ReadFile(filePath)
 		if err != nil {
 			return err
@@ -160,8 +159,8 @@ func walkTmplFiles(dir string, leftDelim string, fn func(filePath string, name s
 		if name != "" {
 			fn(filePath, name)
 		}
-	}
-	return nil
+		return nil
+	})
 }
 
 func extractDefineName(content string, leftDelim string) string {

--- a/template_test.go
+++ b/template_test.go
@@ -207,6 +207,29 @@ func TestNewTemplate_FuncMap(t *testing.T) {
 	assert.Equal(t, "hello!", buf.String())
 }
 
+func TestTemplate_SubdirectoryViews(t *testing.T) {
+	assert.Nil(t, file.PutContent(path.Resource("views", "admin", "index.tmpl"), `{{ define "admin/index.tmpl" }}{{ .greeting }}, {{ .name }}{{ end }}`))
+	assert.Nil(t, file.PutContent(path.Resource("views", "admin", "sidebar.tmpl"), `{{ define "admin/sidebar" }}{{ .greeting }}, {{ .name }}{{ end }}`))
+	defer func() {
+		assert.Nil(t, file.Remove(path.Resource("views")))
+	}()
+
+	mv, err := NewTemplate(RenderOptions{})
+	require.Nil(t, err)
+
+	data := map[string]any{"greeting": "Hello", "name": "Bowen"}
+
+	var buf bytes.Buffer
+	err = mv.Render(&buf, "admin/index.tmpl", data)
+	require.Nil(t, err)
+	assert.Equal(t, "Hello, Bowen", buf.String())
+
+	buf.Reset()
+	err = mv.Render(&buf, "admin/sidebar", data)
+	require.Nil(t, err)
+	assert.Equal(t, "Hello, Bowen", buf.String())
+}
+
 func TestNewTemplate_Layouts(t *testing.T) {
 	assert.Nil(t, file.PutContent(path.Resource("views", "layout.tmpl"), `{{ define "layout" }}<html>{{ template "content" . }}</html>{{ end }}`))
 	assert.Nil(t, file.PutContent(path.Resource("views", "content.tmpl"), `{{ define "content" }}<p>{{ . }}</p>{{ end }}`))


### PR DESCRIPTION
## Summary
- Templates in subdirectories under `resources/views/` are now recursively scanned and loaded
- Both `admin/index.tmpl` (with extension) and `admin/sidebar` (without extension) define-name conventions are supported
- Views render with data correctly from subdirectory templates

## Why
The `walkTmplFiles` function used `os.ReadDir` which only lists entries in the immediate directory, explicitly skipping subdirectories. Templates nested in directories like `resources/views/admin/index.tmpl` were never discovered, causing runtime 500 errors when the example project or any application tried to render views from subdirectories.

This replaces the flat scan with `filepath.WalkDir`, which recursively walks all subdirectories while preserving the existing behavior: only `.tmpl` files with `{{ define }}` blocks are collected.

```go
// Before: templates in resources/views/admin/ were silently ignored
// The following route would return 500 because "admin/index.tmpl" was never loaded:
facades.Route().Get("/admin", func(ctx http.Context) http.Response {
    return ctx.Response().View().Make("admin/index.tmpl", map[string]any{
        "name": "Bowen",
    })
})

// After: subdirectory templates are recursively scanned and render correctly
facades.Route().Get("/admin", func(ctx http.Context) http.Response {
    return ctx.Response().View().Make("admin/index.tmpl", map[string]any{
        "name": "Bowen",
    })
})
```
