### PR TITLE
fix: update middleware to interface pattern for stable WithoutMiddleware comparison

### DIFF
--- a/context_request_test.go
+++ b/context_request_test.go
@@ -2226,12 +2226,16 @@ func TestGetValueFromHttpBody(t *testing.T) {
 	}
 }
 
-// Timeout creates middleware to set a timeout for a request
-func testAllMiddleware() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		all := ctx.Request().All()
-		ctx.WithValue("all", all)
+type testAllMiddlewareType struct{}
 
-		ctx.Request().Next()
-	}
+func (m *testAllMiddlewareType) Signature() string { return "test_all_middleware" }
+
+func (m *testAllMiddlewareType) Handle(ctx contractshttp.Context) {
+	all := ctx.Request().All()
+	ctx.WithValue("all", all)
+	ctx.Request().Next()
+}
+
+func testAllMiddleware() contractshttp.Middleware {
+	return &testAllMiddlewareType{}
 }

--- a/context_response.go
+++ b/context_response.go
@@ -226,7 +226,7 @@ func (r *Status) Stream(step func(w contractshttp.StreamWriter) error) contracts
 type responseMiddleware struct{}
 
 func (m *responseMiddleware) Signature() string {
-	return "goravel_fiber_response"
+	return "goravel:response"
 }
 
 func (m *responseMiddleware) Handle(ctx contractshttp.Context) {

--- a/context_response.go
+++ b/context_response.go
@@ -223,15 +223,23 @@ func (r *Status) Stream(step func(w contractshttp.StreamWriter) error) contracts
 	return &StreamResponse{r.status, r.instance, step}
 }
 
-func ResponseMiddleware() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		switch ctx := ctx.(type) {
-		case *Context:
-			ctx.Instance().Response().ResetBody()
-		}
+type responseMiddleware struct{}
 
-		ctx.Request().Next()
+func (m *responseMiddleware) Signature() string {
+	return "goravel_fiber_response"
+}
+
+func (m *responseMiddleware) Handle(ctx contractshttp.Context) {
+	switch ctx := ctx.(type) {
+	case *Context:
+		ctx.Instance().Response().ResetBody()
 	}
+
+	ctx.Request().Next()
+}
+
+func ResponseMiddleware() contractshttp.Middleware {
+	return &responseMiddleware{}
 }
 
 type ResponseOrigin struct {

--- a/context_response_test.go
+++ b/context_response_test.go
@@ -274,15 +274,7 @@ func TestResponse(t *testing.T) {
 			url:    "/origin",
 			setup: func(method, url string) error {
 				route.setMiddlewares([]fiber.Handler{
-					middlewareToFiberHandler(func(ctx contractshttp.Context) {
-						ctx.Response().Header("global", "goravel")
-						ctx.Request().Next()
-
-						assert.Equal(t, "Goravel", ctx.Response().Origin().Body().String())
-						assert.Equal(t, "goravel", ctx.Response().Origin().Header().Get("global"))
-						assert.Equal(t, 7, ctx.Response().Origin().Size())
-						assert.Equal(t, 200, ctx.Response().Origin().Status())
-					}),
+				middlewareToFiberHandler(&headerOriginMwType{t: t}),
 				})
 				route.Get("/origin", func(ctx contractshttp.Context) contractshttp.Response {
 					return ctx.Response().String(http.StatusOK, "Goravel")
@@ -778,4 +770,19 @@ func TestResponse_Stream(t *testing.T) {
 
 	assert.Equal(t, []string{"a", "b", "c"}, output)
 
+}
+
+type headerOriginMwType struct {
+	t *testing.T
+}
+
+func (m *headerOriginMwType) Signature() string { return "test_header_origin_mw" }
+
+func (m *headerOriginMwType) Handle(ctx contractshttp.Context) {
+	ctx.Response().Header("global", "goravel")
+	ctx.Request().Next()
+	assert.Equal(m.t, "Goravel", ctx.Response().Origin().Body().String())
+	assert.Equal(m.t, "goravel", ctx.Response().Origin().Header().Get("global"))
+	assert.Equal(m.t, 7, ctx.Response().Origin().Size())
+	assert.Equal(m.t, 200, ctx.Response().Origin().Status())
 }

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ toolchain go1.25.6
 require (
 	github.com/gofiber/fiber/v3 v3.3.0
 	github.com/gofiber/utils/v2 v2.1.0
-	github.com/goravel/framework v1.17.2-0.20260621064957-8c973e865adb
 	github.com/spf13/cast v1.10.0
 	github.com/stretchr/testify v1.11.1
 	github.com/valyala/fasthttp v1.71.0
@@ -53,6 +52,7 @@ require (
 	github.com/goforj/godump v1.9.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/gookit/color v1.6.0 // indirect
+	github.com/goravel/framework v1.17.2-0.20260627084235-9e93358bfb27
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
@@ -126,6 +126,3 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/gorm v1.31.1 // indirect
 )
-
-// TODO: remove after framework PR is merged
-replace github.com/goravel/framework => github.com/u-wlkjyy/framework v1.17.2-0.20260621064957-8c973e865adb

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,8 @@ github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQ
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
 github.com/gookit/color v1.6.0 h1:JjJXBTk1ETNyqyilJhkTXJYYigHG24TM9Xa2M1xAhRA=
 github.com/gookit/color v1.6.0/go.mod h1:9ACFc7/1IpHGBW8RwuDm/0YEnhg3dwwXpoMsmtyHfjs=
+github.com/goravel/framework v1.17.2-0.20260627084235-9e93358bfb27 h1:WYEVATW02ByS9Lv7/87lqnc8WCo6yWGKUenrMIno5eE=
+github.com/goravel/framework v1.17.2-0.20260627084235-9e93358bfb27/go.mod h1:P+VHYPXl+gYyzdUixJCIujFNEmsK5IveNSLoFeY4uqo=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
 github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD/E=
@@ -234,8 +236,6 @@ github.com/subosito/gotenv v1.6.0 h1:9NlTDc1FTs4qu0DDq7AEtTPNw6SVm7uBMsUCUjABIf8
 github.com/subosito/gotenv v1.6.0/go.mod h1:Dk4QP5c2W3ibzajGcXpNraDfq2IrhjMIvMSWPKKo0FU=
 github.com/tinylib/msgp v1.6.4 h1:mOwYbyYDLPj35mkA2BjjYejgJk9BuHxDdvRnb6v2ZcQ=
 github.com/tinylib/msgp v1.6.4/go.mod h1:RSp0LW9oSxFut3KzESt5Voq4GVWyS+PSulT77roAqEA=
-github.com/u-wlkjyy/framework v1.17.2-0.20260621064957-8c973e865adb h1:052mJgGyRtXRfLrpcMpTZMRwQr+ogVdABfHdZrxd/rk=
-github.com/u-wlkjyy/framework v1.17.2-0.20260621064957-8c973e865adb/go.mod h1:J3xvbbFAbS/sYePrlIMfUD6anGcrnE49mnntYlKUvls=
 github.com/urfave/cli/v3 v3.10.0 h1:0aU8yOObVDMkM13Cj4G+zb4P0PdeJMec65f81Ak1ioM=
 github.com/urfave/cli/v3 v3.10.0/go.mod h1:ysVLtOEmg2tOy6PknnYVhDoouyC/6N42TMeoMzskhso=
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=

--- a/group.go
+++ b/group.go
@@ -199,7 +199,7 @@ func (r *Group) getMiddlewares(handler contractshttp.HandlerFunc) []fiber.Handle
 }
 
 // excludeMiddlewares filters out middlewares excluded via WithoutMiddleware,
-// comparing by reflect.Type (see isSameMiddleware in utils.go).
+// comparing by Signature() (see isSameMiddleware in utils.go).
 func (r *Group) excludeMiddlewares(middlewares []contractshttp.Middleware) []contractshttp.Middleware {
 	if len(r.excludedMiddlewares) == 0 {
 		return middlewares

--- a/group_test.go
+++ b/group_test.go
@@ -164,10 +164,7 @@ func (s *GroupTestSuite) TestAny() {
 
 func (s *GroupTestSuite) TestResource() {
 	s.route.setMiddlewares([]fiber.Handler{
-		middlewareToFiberHandler(func(ctx contractshttp.Context) {
-			ctx.WithValue("action", ctx.Request().Origin().Method)
-			ctx.Request().Next()
-		}),
+		middlewareToFiberHandler(&actionMiddlewareType{}),
 	})
 	s.route.Resource("/resource", resourceController{}).Name("resource")
 
@@ -307,10 +304,7 @@ func (s *GroupTestSuite) TestGlobalMiddleware() {
 	s.mockConfig.EXPECT().GetBool("app.debug", false).Return(true).Once()
 	s.mockConfig.EXPECT().GetString("app.timezone", "UTC").Return("UTC").Once()
 
-	s.route.GlobalMiddleware(func(ctx contractshttp.Context) {
-		ctx.WithValue("global", "goravel")
-		ctx.Request().Next()
-	})
+	s.route.GlobalMiddleware(&globalMiddlewareTestType{})
 	s.route.Get("/global-middleware", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Json(http.StatusOK, contractshttp.Json{
 			"global": ctx.Value("global"),
@@ -361,10 +355,7 @@ func (s *GroupTestSuite) TestIssue408() {
 }
 
 func (s *GroupTestSuite) TestWithoutMiddleware() {
-	mw := func(ctx contractshttp.Context) {
-		ctx.WithValue("mw", "applied")
-		ctx.Request().Next()
-	}
+	mw := contractshttp.Middleware(&withoutMiddlewareType{})
 
 	s.route.Middleware(mw).WithoutMiddleware(mw).Get("/without", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Json(http.StatusOK, contractshttp.Json{
@@ -376,10 +367,7 @@ func (s *GroupTestSuite) TestWithoutMiddleware() {
 }
 
 func (s *GroupTestSuite) TestActionWithoutMiddleware() {
-	mw := func(ctx contractshttp.Context) {
-		ctx.WithValue("mw", "applied")
-		ctx.Request().Next()
-	}
+	mw := contractshttp.Middleware(&withoutMiddlewareType{})
 
 	s.route.Middleware(mw).Get("/without-action", func(ctx contractshttp.Context) contractshttp.Response {
 		return ctx.Response().Json(http.StatusOK, contractshttp.Json{
@@ -415,34 +403,74 @@ func (s *GroupTestSuite) assert(method, url string, expectCode int, expectBody s
 	}
 }
 
-func abortMiddleware() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		ctx.Request().Abort(http.StatusNonAuthoritativeInfo)
-	}
+type abortMiddlewareType struct{}
+
+func (m *abortMiddlewareType) Signature() string { return "test_abort_middleware" }
+
+func (m *abortMiddlewareType) Handle(ctx contractshttp.Context) {
+	ctx.Request().Abort(http.StatusNonAuthoritativeInfo)
 }
 
-func contextMiddleware() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		ctx.WithValue("ctx", "Goravel")
+func abortMiddleware() contractshttp.Middleware { return &abortMiddlewareType{} }
 
-		ctx.Request().Next()
-	}
+type contextMiddlewareType struct{}
+
+func (m *contextMiddlewareType) Signature() string { return "test_context_middleware" }
+
+func (m *contextMiddlewareType) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("ctx", "Goravel")
+	ctx.Request().Next()
 }
 
-func contextMiddleware1() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		ctx.WithValue("ctx1", "Hello")
+func contextMiddleware() contractshttp.Middleware { return &contextMiddlewareType{} }
 
-		ctx.Request().Next()
-	}
+type contextMiddleware1Type struct{}
+
+func (m *contextMiddleware1Type) Signature() string { return "test_context_middleware_1" }
+
+func (m *contextMiddleware1Type) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("ctx1", "Hello")
+	ctx.Request().Next()
 }
 
-func contextMiddleware2() contractshttp.Middleware {
-	return func(ctx contractshttp.Context) {
-		ctx.WithValue("ctx2", "World")
+func contextMiddleware1() contractshttp.Middleware { return &contextMiddleware1Type{} }
 
-		ctx.Request().Next()
-	}
+type contextMiddleware2Type struct{}
+
+func (m *contextMiddleware2Type) Signature() string { return "test_context_middleware_2" }
+
+func (m *contextMiddleware2Type) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("ctx2", "World")
+	ctx.Request().Next()
+}
+
+func contextMiddleware2() contractshttp.Middleware { return &contextMiddleware2Type{} }
+
+type globalMiddlewareTestType struct{}
+
+func (m *globalMiddlewareTestType) Signature() string { return "test_global_middleware" }
+
+func (m *globalMiddlewareTestType) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("global", "goravel")
+	ctx.Request().Next()
+}
+
+type withoutMiddlewareType struct{}
+
+func (m *withoutMiddlewareType) Signature() string { return "test_without_mw" }
+
+func (m *withoutMiddlewareType) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("mw", "applied")
+	ctx.Request().Next()
+}
+
+type actionMiddlewareType struct{}
+
+func (m *actionMiddlewareType) Signature() string { return "test_action_mw" }
+
+func (m *actionMiddlewareType) Handle(ctx contractshttp.Context) {
+	ctx.WithValue("action", ctx.Request().Origin().Method)
+	ctx.Request().Next()
 }
 
 type resourceController struct{}

--- a/middleware_cors.go
+++ b/middleware_cors.go
@@ -10,7 +10,7 @@ import (
 type corsMiddleware struct{}
 
 func (m *corsMiddleware) Signature() string {
-	return "goravel_fiber_cors"
+	return "goravel:cors"
 }
 
 func (m *corsMiddleware) Handle(ctx http.Context) {

--- a/middleware_cors.go
+++ b/middleware_cors.go
@@ -7,50 +7,58 @@ import (
 	"github.com/goravel/framework/contracts/http"
 )
 
-func Cors() http.Middleware {
-	return func(ctx http.Context) {
-		path := ctx.Request().Path()
-		corsPaths, ok := ConfigFacade.Get("cors.paths").([]string)
-		if !ok {
-			ctx.Request().Next()
-			return
-		}
+type corsMiddleware struct{}
 
-		needCors := false
-		for _, corsPath := range corsPaths {
-			corsPath = pathToFiberPath(corsPath)
-			if strings.HasSuffix(corsPath, "*") {
-				corsPath = strings.ReplaceAll(corsPath, "*", "")
-				if corsPath == "" || strings.HasPrefix(strings.TrimPrefix(path, "/"), strings.TrimPrefix(corsPath, "/")) {
-					needCors = true
-					break
-				}
-			} else {
-				if strings.TrimPrefix(path, "/") == strings.TrimPrefix(corsPath, "/") {
-					needCors = true
-					break
-				}
+func (m *corsMiddleware) Signature() string {
+	return "goravel_fiber_cors"
+}
+
+func (m *corsMiddleware) Handle(ctx http.Context) {
+	path := ctx.Request().Path()
+	corsPaths, ok := ConfigFacade.Get("cors.paths").([]string)
+	if !ok {
+		ctx.Request().Next()
+		return
+	}
+
+	needCors := false
+	for _, corsPath := range corsPaths {
+		corsPath = pathToFiberPath(corsPath)
+		if strings.HasSuffix(corsPath, "*") {
+			corsPath = strings.ReplaceAll(corsPath, "*", "")
+			if corsPath == "" || strings.HasPrefix(strings.TrimPrefix(path, "/"), strings.TrimPrefix(corsPath, "/")) {
+				needCors = true
+				break
+			}
+		} else {
+			if strings.TrimPrefix(path, "/") == strings.TrimPrefix(corsPath, "/") {
+				needCors = true
+				break
 			}
 		}
-
-		if !needCors {
-			ctx.Request().Next()
-			return
-		}
-
-		fiberCtx := ctx.(*Context)
-		handler := cors.New(cors.Config{
-			AllowMethods:     allowedMethods(),
-			AllowOrigins:     allowedOrigins(),
-			AllowHeaders:     allowedHeaders(),
-			ExposeHeaders:    exposedHeaders(),
-			MaxAge:           ConfigFacade.GetInt("cors.max_age"),
-			AllowCredentials: ConfigFacade.GetBool("cors.supports_credentials"),
-		})
-		if err := handler(fiberCtx.Instance()); err != nil {
-			panic(err)
-		}
 	}
+
+	if !needCors {
+		ctx.Request().Next()
+		return
+	}
+
+	fiberCtx := ctx.(*Context)
+	handler := cors.New(cors.Config{
+		AllowMethods:     allowedMethods(),
+		AllowOrigins:     allowedOrigins(),
+		AllowHeaders:     allowedHeaders(),
+		ExposeHeaders:    exposedHeaders(),
+		MaxAge:           ConfigFacade.GetInt("cors.max_age"),
+		AllowCredentials: ConfigFacade.GetBool("cors.supports_credentials"),
+	})
+	if err := handler(fiberCtx.Instance()); err != nil {
+		panic(err)
+	}
+}
+
+func Cors() http.Middleware {
+	return &corsMiddleware{}
 }
 
 func allowedMethods() []string {

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -15,7 +15,7 @@ type timeoutMiddleware struct {
 }
 
 func (m *timeoutMiddleware) Signature() string {
-	return "goravel_fiber_timeout"
+	return "goravel:timeout"
 }
 
 func (m *timeoutMiddleware) Handle(ctx contractshttp.Context) {

--- a/middleware_timeout.go
+++ b/middleware_timeout.go
@@ -10,11 +10,36 @@ import (
 	contractshttp "github.com/goravel/framework/contracts/http"
 )
 
+type timeoutMiddleware struct {
+	handler fiber.Handler
+}
+
+func (m *timeoutMiddleware) Signature() string {
+	return "goravel_fiber_timeout"
+}
+
+func (m *timeoutMiddleware) Handle(ctx contractshttp.Context) {
+	fiberCtx := ctx.(*Context)
+	fiberCtx.Instance().SetContext(fiberCtx.Context())
+
+	if err := m.handler(fiberCtx.Instance()); err != nil && !errors.Is(err, fiber.ErrRequestTimeout) {
+		if err := renderFiberError(fiberCtx.Instance(), err); err != nil {
+			panic(err)
+		}
+	}
+}
+
 // Timeout creates middleware to set a timeout for a request.
 // NOTICE: It relies on Fiber's timeout middleware so timed-out requests get a 408 response
 // without recycling the underlying request context into a later request.
 // For details, see https://github.com/valyala/fasthttp/issues/965
 func Timeout(timeout time.Duration) contractshttp.Middleware {
+	if timeout <= 0 {
+		return &timeoutMiddleware{handler: func(c fiber.Ctx) error {
+			return c.Next()
+		}}
+	}
+
 	handler := fibertimeout.New(func(c fiber.Ctx) (err error) {
 		// Mirror Fiber's timeout-aware context into Goravel's request context so
 		// downstream handlers observe the same deadline and cancellation signal.
@@ -34,22 +59,5 @@ func Timeout(timeout time.Duration) contractshttp.Middleware {
 		return c.Next()
 	}, fibertimeout.Config{Timeout: timeout})
 
-	return func(ctx contractshttp.Context) {
-		if timeout <= 0 {
-			ctx.Request().Next()
-			return
-		}
-
-		fiberCtx := ctx.(*Context)
-		// Seed Fiber with the current Goravel context before timeout.New wraps it,
-		// otherwise upstream WithContext values would be lost when Fiber derives
-		// the timeout-aware context exposed through c.Context().
-		fiberCtx.Instance().SetContext(fiberCtx.Context())
-
-		if err := handler(fiberCtx.Instance()); err != nil && !errors.Is(err, fiber.ErrRequestTimeout) {
-			if err := renderFiberError(fiberCtx.Instance(), err); err != nil {
-				panic(err)
-			}
-		}
-	}
+	return &timeoutMiddleware{handler: handler}
 }

--- a/middleware_timeout_test.go
+++ b/middleware_timeout_test.go
@@ -54,10 +54,7 @@ func TestTimeoutMiddleware(t *testing.T) {
 
 	timeoutContextValue := make(chan string, 1)
 
-	route.Middleware(func(ctx contractshttp.Context) {
-		ctx.WithContext(context.WithValue(ctx.Context(), requestIDKey, "goravel-timeout"))
-		ctx.Request().Next()
-	}, Timeout(100*time.Millisecond)).Get("/timeout-context-value", func(ctx contractshttp.Context) contractshttp.Response {
+	route.Middleware(&timeoutContextMwType{requestIDKey: requestIDKey}, Timeout(100*time.Millisecond)).Get("/timeout-context-value", func(ctx contractshttp.Context) contractshttp.Response {
 		timeoutContextValue <- ctx.Value(requestIDKey).(string)
 		<-ctx.Done()
 		return nil
@@ -255,4 +252,15 @@ func TestTimeoutMiddleware(t *testing.T) {
 
 		<-panicDone
 	})
+}
+
+type timeoutContextMwType struct {
+	requestIDKey any
+}
+
+func (m *timeoutContextMwType) Signature() string { return "test_timeout_context_mw" }
+
+func (m *timeoutContextMwType) Handle(ctx contractshttp.Context) {
+	ctx.WithContext(context.WithValue(ctx.Context(), m.requestIDKey, "goravel-timeout"))
+	ctx.Request().Next()
 }

--- a/route.go
+++ b/route.go
@@ -344,15 +344,7 @@ func (r *Route) init(globalMiddleware []contractshttp.Middleware) error {
 		}))
 	}
 
-	recoverMiddleware := func(ctx contractshttp.Context) {
-		defer func() {
-			if err := recover(); err != nil {
-				globalRecoverCallback(ctx, err)
-			}
-		}()
-		ctx.Request().Next()
-	}
-	globalMiddleware = append([]contractshttp.Middleware{recoverMiddleware}, globalMiddleware...)
+	globalMiddleware = append([]contractshttp.Middleware{&recoverMiddleware{}}, globalMiddleware...)
 	handlers = append(handlers, middlewaresToFiberHandlers(globalMiddleware)...)
 
 	for _, handler := range handlers {
@@ -406,4 +398,19 @@ func (r *Route) setMiddlewares(middlewares []fiber.Handler) {
 func defaultRecoverCallback(ctx contractshttp.Context, err any) {
 	LogFacade.WithContext(ctx).Request(ctx.Request()).Error(err)
 	ctx.Request().Abort(contractshttp.StatusInternalServerError)
+}
+
+type recoverMiddleware struct{}
+
+func (m *recoverMiddleware) Signature() string {
+	return "goravel_fiber_recover"
+}
+
+func (m *recoverMiddleware) Handle(ctx contractshttp.Context) {
+	defer func() {
+		if err := recover(); err != nil {
+			globalRecoverCallback(ctx, err)
+		}
+	}()
+	ctx.Request().Next()
 }

--- a/route.go
+++ b/route.go
@@ -403,7 +403,7 @@ func defaultRecoverCallback(ctx contractshttp.Context, err any) {
 type recoverMiddleware struct{}
 
 func (m *recoverMiddleware) Signature() string {
-	return "goravel_fiber_recover"
+	return "goravel:recover"
 }
 
 func (m *recoverMiddleware) Handle(ctx contractshttp.Context) {

--- a/route_test.go
+++ b/route_test.go
@@ -183,7 +183,7 @@ func (s *RouteTestSuite) TestGlobalMiddleware() {
 	s.mockConfig.EXPECT().GetBool("app.debug", false).Return(true).Once()
 	s.mockConfig.EXPECT().GetString("app.timezone", "UTC").Return("UTC").Once()
 
-	middleware := func(ctx contractshttp.Context) {}
+	middleware := contractshttp.Middleware(&globalMwTestType{})
 	s.route.GlobalMiddleware(middleware)
 	s.Equal(uint32(4), s.route.instance.HandlersCount())
 }
@@ -698,6 +698,12 @@ func assertHttpNormal(t *testing.T, addr string, expectNormal bool) {
 		}
 	}
 }
+
+type globalMwTestType struct{}
+
+func (m *globalMwTestType) Handle(contractshttp.Context) {}
+
+func (m *globalMwTestType) Signature() string { return "test_global_mw" }
 
 type CreateUser struct {
 	Name string `form:"name" json:"name"`

--- a/utils.go
+++ b/utils.go
@@ -2,7 +2,6 @@ package fiber
 
 import (
 	"errors"
-	"reflect"
 	"regexp"
 	"strings"
 
@@ -61,7 +60,7 @@ func middlewareToFiberHandler(middleware httpcontract.Middleware) fiber.Handler 
 			}
 		}
 
-		middleware(context)
+		middleware.Handle(context)
 		return nil
 	}
 }
@@ -117,21 +116,14 @@ func mergeSlashForPath(path string) string {
 	return strings.ReplaceAll(path, "//", "/")
 }
 
-// isSameMiddleware reports whether two middleware values have the same concrete
-// type (dereferencing pointers). This lets WithoutMiddleware match struct-based
-// middleware across different instances. Closure-based middleware (func(Context))
-// share a single reflect.Type and cannot be told apart — a documented limitation.
+// isSameMiddleware reports whether two middleware values identify the same
+// middleware by comparing their Signature() strings. This gives every middleware
+// a stable, comparable identity, even parameterized ones like Throttle("api").
 func isSameMiddleware(a, b any) bool {
-	tA := reflect.TypeOf(a)
-	tB := reflect.TypeOf(b)
-	if tA == nil || tB == nil {
+	mA, okA := a.(httpcontract.Middleware)
+	mB, okB := b.(httpcontract.Middleware)
+	if !okA || !okB {
 		return false
 	}
-	if tA.Kind() == reflect.Pointer {
-		tA = tA.Elem()
-	}
-	if tB.Kind() == reflect.Pointer {
-		tB = tB.Elem()
-	}
-	return tA == tB
+	return mA.Signature() == mB.Signature()
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -3,6 +3,7 @@ package fiber
 import (
 	"testing"
 
+	contractshttp "github.com/goravel/framework/contracts/http"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -15,13 +16,18 @@ func TestColonToBracket(t *testing.T) {
 }
 
 func TestIsSameMiddleware(t *testing.T) {
-	type mwA struct{}
-	type mwB struct{}
+	mw1 := &testMiddleware{id: "foo"}
+	mw2 := &testMiddleware{id: "foo"}
+	mw3 := &testMiddleware{id: "bar"}
 
-	assert.True(t, isSameMiddleware(&mwA{}, &mwA{}))
-	assert.False(t, isSameMiddleware(&mwA{}, &mwB{}))
-	fn1 := func() {}
-	fn2 := func() {}
-	assert.True(t, isSameMiddleware(fn1, fn2))
-	assert.False(t, isSameMiddleware(nil, fn1))
+	assert.True(t, isSameMiddleware(mw1, mw2))
+	assert.False(t, isSameMiddleware(mw1, mw3))
+	assert.False(t, isSameMiddleware(nil, mw1))
+	assert.False(t, isSameMiddleware("not middleware", mw1))
 }
+
+type testMiddleware struct{ id string }
+
+func (m *testMiddleware) Handle(contractshttp.Context) {}
+
+func (m *testMiddleware) Signature() string { return m.id }


### PR DESCRIPTION
## Summary
- `WithoutMiddleware` now correctly excludes only the specified middleware using `Signature()` string comparison instead of `reflect.TypeOf`
- All fiber driver middlewares (CORS, Timeout, recover, ResponseMiddleware) converted from closure to struct-based interface pattern
- Updated framework dependency to `goravel/framework@9e93358` for the `contractshttp.Middleware` interface contract

## Why
The `WithoutMiddleware` feature previously used `reflect.TypeOf` to identify which middleware to exclude. Since `contractshttp.Middleware` was a bare `func(Context)`, every closure-based middleware shared the same type — making `WithoutMiddleware(Cors())` silently exclude **all** middleware, not just `Cors()`.

By changing `Middleware` to an interface with `Handle(Context)` and `Signature() string` methods, every middleware has a stable, comparable identity. The fiber driver now compares `excluded.Signature() == current.Signature()` — a trivial string comparison that is always correct, even for parameterized middleware.

```go
// Before: WithoutMiddleware(Cors()) silently excluded ALL middlewares
facades.Route().Middleware(Cors(), Timeout(3*time.Second)).Group(func(r route.Router) {
    r.Get("/api/internal", internalHandler).WithoutMiddleware(Cors())
    // BUG: both Cors() and Timeout(3s) were excluded
})

// After: only Cors() is excluded, Timeout(3s) still applies
facades.Route().Middleware(Cors(), Timeout(3*time.Second)).Group(func(r route.Router) {
    r.Get("/api/internal", internalHandler).WithoutMiddleware(Cors())
    // Correct: only Cors() excluded
})
```
